### PR TITLE
empty test observation coverage plot

### DIFF
--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -409,6 +409,76 @@ def plot_observation_positions(
         ax.set_title(title)
     return ax
 
+def plot_observation_periods(
+    observations: List[Observation],
+    show_model=False,
+    limit_to_model_period=False,
+    marker="_",
+    title=None,
+    figsize=None,
+):
+    """Plot graph showing temporal coverage for all observations
+
+    Parameters
+    ----------
+    show_model : bool, optional
+        Show model(s) as separate lines on plot, by default True
+    limit_to_model_period : bool, optional
+        Show temporal coverage only for period covered
+        by the model, by default True
+    marker : str, optional
+        plot marker for observations, by default "_"
+    title: str, optional
+        plot title, default empty
+    figsize : Tuple(float, float), optional
+        size of figure, by default (7, 0.45*n_lines)
+
+    Examples
+    --------
+    >>> con.plot_temporal_coverage()
+    >>> con.plot_temporal_coverage(show_model=False)
+    >>> con.plot_temporal_coverage(limit_to_model_period=False)
+    >>> con.plot_temporal_coverage(marker=".")
+    >>> con.plot_temporal_coverage(figsize=(5,3))
+    """
+    #n_models = self.n_models if show_model else 0
+    n_lines = len(observations)
+    if figsize is None:
+        ysize = max(2.0, 0.45 * n_lines)
+        figsize = (7, ysize)
+
+    fig, ax = plt.subplots(figsize=figsize)
+    y = np.repeat(0.0, 2)
+    labels = []
+
+    if show_model:
+        for key, mr in self.modelresults.items():
+            y += 1.0
+            plt.plot([mr.start_time, mr.end_time], y)
+            labels.append(key)
+            
+    observations = observations.copy()
+    observations.reverse()
+    for obs in observations:
+        y += 1.0
+        plt.plot(obs.time, y[0] * np.ones_like(obs.values), marker, markersize=5)
+        labels.append(obs.name)
+
+    if limit_to_model_period:
+        mr = list(self.modelresults.values())[0]  # take first
+        plt.xlim([mr.start_time, mr.end_time])
+
+    plt.yticks(np.arange(n_lines) + 1, labels)
+    if show_model:
+        for j in range(n_models):
+            ax.get_yticklabels()[j].set_fontstyle("italic")
+            ax.get_yticklabels()[j].set_weight("bold")
+            # set_color("#004165")
+    fig.autofmt_xdate()
+
+    if title:
+        ax.set_title(title)
+    return ax
 
 TaylorPoint = namedtuple("TaylorPoint", "name obs_std std cc marker marker_size")
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,0 +1,4 @@
+import fmskill
+
+def test_observation_coverage_plot():
+    pass


### PR DESCRIPTION
@ecomodeller and @jsmariegaard , working on the long list of ideas  #132 will likely fix this, but I need an ad-hoc solution _now_ :-)

I can think of two approaches:
1. Add `fmskill.plot.plot_observation_coverage()`, which can be called by the `Connector` or stand alone. This would be consistent with the other plot methods here, such as `fmskill.plot.plot_observation_positions`, which is called [here](https://github.com/DHI/fmskill/blob/3c0bae70210924e52d356b5b8259c2e243b8aa8c/fmskill/connection.py#L584).
2. Allow a connection without a model result: `Connector([o1, o2, o3], '')`

I feel that 2 is more overlapping with a general rework, so my proposal for now would be option 1.

Thoughts? Other options?