### PR TITLE
Refactor `scatter()`

### DIFF
--- a/modelskill/comparison.py
+++ b/modelskill/comparison.py
@@ -2056,8 +2056,6 @@ class ComparerCollection(Mapping, Sequence):
         start: TimeTypes = None,
         end: TimeTypes = None,
         area: List[float] = None,
-        binsize: float = None,
-        nbins: int = None,
         skill_table: Union[str, List[str], bool] = None,
         **kwargs,
     ):
@@ -2198,8 +2196,6 @@ class ComparerCollection(Mapping, Sequence):
             ylabel=ylabel,
             skill_df=skill_df,
             units=units,
-            binsize=binsize,
-            nbins=nbins,
             **kwargs,
         )
         return ax

--- a/modelskill/comparison.py
+++ b/modelskill/comparison.py
@@ -1240,8 +1240,6 @@ class Comparer:
             ylabel=ylabel,
             skill_df=skill_df,
             units=units,
-            binsize=binsize,
-            nbins=nbins,
             **kwargs,
         )
         return ax

--- a/modelskill/plot.py
+++ b/modelskill/plot.py
@@ -57,6 +57,49 @@ register_option(
 register_option("plot.scatter.legend.fontsize", 12, validator=settings.is_positive)
 
 
+def _sample_points(x, y, show_points: bool):
+    x_sample = x
+    y_sample = y
+    sample_warning = False
+    if show_points is None:
+        # If nothing given, and more than 50k points, 50k sample will be shown
+        if len(x) < 5e4:
+            show_points = True
+        else:
+            show_points = 50000
+            sample_warning = True
+    if type(show_points) == float:
+        if show_points < 0 or show_points > 1:
+            raise ValueError(" `show_points` fraction must be in [0,1]")
+        else:
+            np.random.seed(20)
+            ran_index = np.random.choice(
+                range(len(x)), int(len(x) * show_points), replace=False
+            )
+            x_sample = x[ran_index]
+            y_sample = y[ran_index]
+            if len(x_sample) < len(x):
+                sample_warning = True
+    # if show_points is an int
+    elif type(show_points) == int:
+        np.random.seed(20)
+        ran_index = np.random.choice(range(len(x)), show_points, replace=False)
+        x_sample = x[ran_index]
+        y_sample = y[ran_index]
+        if len(x_sample) < len(x):
+            sample_warning = True
+    elif type(show_points) == bool:
+        pass
+    else:
+        raise TypeError(" `show_points` must be either bool, int or float")
+    if sample_warning:
+        warnings.warn(
+            message=f"Showing only {len(x_sample)} points in plot. If all scatter points wanted in plot, use `show_points=True`",
+            stacklevel=2,
+        )
+    return x_sample, y_sample
+
+
 def scatter(
     x,
     y,
@@ -155,45 +198,8 @@ def scatter(
     if len(x) != len(y):
         raise ValueError("x & y are not of equal length")
 
-    x_sample = x
-    y_sample = y
-    sample_warning = False
-    if show_points is None:
-        # If nothing given, and more than 50k points, 50k sample will be shown
-        if len(x) < 5e4:
-            show_points = True
-        else:
-            show_points = 50000
-            sample_warning = True
-    if type(show_points) == float:
-        if show_points < 0 or show_points > 1:
-            raise ValueError(" `show_points` fraction must be in [0,1]")
-        else:
-            np.random.seed(20)
-            ran_index = np.random.choice(
-                range(len(x)), int(len(x) * show_points), replace=False
-            )
-            x_sample = x[ran_index]
-            y_sample = y[ran_index]
-            if len(x_sample) < len(x):
-                sample_warning = True
-    # if show_points is an int
-    elif type(show_points) == int:
-        np.random.seed(20)
-        ran_index = np.random.choice(range(len(x)), show_points, replace=False)
-        x_sample = x[ran_index]
-        y_sample = y[ran_index]
-        if len(x_sample) < len(x):
-            sample_warning = True
-    elif type(show_points) == bool:
-        pass
-    else:
-        raise TypeError(" `show_points` must be either bool, int or float")
-    if sample_warning:
-        warnings.warn(
-            message=f"Showing only {len(x_sample)} points in plot. If all scatter points wanted in plot, use `show_points=True`",
-            stacklevel=2,
-        )
+    x_sample, y_sample = _sample_points(x, y, show_points)
+
     xmin, xmax = x.min(), x.max()
     ymin, ymax = y.min(), y.max()
     xymin = min([xmin, ymin])

--- a/modelskill/plot.py
+++ b/modelskill/plot.py
@@ -119,6 +119,38 @@ def sample_points(
     return x_sample, y_sample
 
 
+def quantiles_xy(
+    x: np.ndarray, y: np.ndarray, quantiles: Union[int, Sequence[float]] = None
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Calculate quantiles of x and y
+
+    Parameters
+    ----------
+    x: np.ndarray, 1d        
+    y: np.ndarray, 1d
+    q: int, Sequence[float]
+        quantiles to calculate
+
+    Returns
+    -------
+    np.ndarray, np.ndarray
+        x and y arrays with quantiles
+    """
+
+    if quantiles is None:
+        if len(x) >= 3000:
+            quantiles = 1000
+        elif len(x) >= 300:
+            quantiles = 100
+        else:
+            quantiles = 10
+
+    if not isinstance(quantiles, (int, Sequence)):
+        raise TypeError("quantiles must be an int or sequence of floats")
+    
+    q = np.linspace(0, 1, num=quantiles) if isinstance(quantiles, int) else quantiles
+    return np.quantile(x, q=q), np.quantile(y, q=q)
+
 def _scatter_matplotlib(
     *,
     x,
@@ -437,20 +469,13 @@ def scatter(
         raise ValueError("x & y are not of equal length")
 
     x_sample, y_sample = sample_points(x, y, show_points)
+    xq, yq = quantiles_xy(x, y, quantiles)
 
     xmin, xmax = x.min(), x.max()
     ymin, ymax = y.min(), y.max()
     xymin = min([xmin, ymin])
     xymax = max([xmax, ymax])
-
-    if quantiles is None:
-        if len(x) >= 3000:
-            quantiles = 1000
-        elif len(x) >= 300:
-            quantiles = 100
-        else:
-            quantiles = 10
-
+    
     nbins_hist, binsize = _get_bins(bins, xymin=xymin, xymax=xymax)
 
     if xlim is None:
@@ -459,14 +484,6 @@ def scatter(
     if ylim is None:
         ylim = (xymin - binsize, xymax + binsize)
 
-    if isinstance(quantiles, int):
-        xq = np.quantile(x, q=np.linspace(0, 1, num=quantiles))
-        yq = np.quantile(y, q=np.linspace(0, 1, num=quantiles))
-    elif isinstance(quantiles, Sequence):
-        xq = np.quantile(x, q=quantiles)
-        yq = np.quantile(y, q=quantiles)
-    else:
-        raise TypeError("quantiles must be an int or sequence of floats")
 
     x_trend = np.array([xlim[0], xlim[1]])
 

--- a/modelskill/plot.py
+++ b/modelskill/plot.py
@@ -120,8 +120,6 @@ def scatter(
     ylabel: str = "",
     skill_df: object = None,
     units: str = "",
-    binsize: float = None,
-    nbins: int = None,
     **kwargs,
 ):
     """Scatter plot showing compared data: observation vs modelled
@@ -185,16 +183,6 @@ def scatter(
         # Default: points density
         show_density = True
 
-    if (binsize is not None) or (nbins is not None):
-        warnings.warn(
-            "`binsize` and `nbins` are deprecated and will be removed soon, use `bins` instead",
-        )
-        binsize_aux = binsize
-        nbins_aux = nbins
-    else:
-        binsize_aux = None
-        nbins_aux = None
-
     if len(x) != len(y):
         raise ValueError("x & y are not of equal length")
 
@@ -223,15 +211,6 @@ def scatter(
         # Then bins = Sequence
         binsize = bins
         nbins_hist = bins
-
-    # Check deprecated kwords; Remove this verification in future release
-    if (binsize_aux is not None) or (nbins_aux is not None):
-        if binsize_aux is None:
-            binsize = (xmax - xmin) / nbins_aux
-            nbins_hist = nbins_aux
-        else:
-            nbins_hist = int((xmax - xmin) / binsize_aux)
-    # Remove previous piece of code when nbins and bin_size are deprecated.
 
     if xlim is None:
         xlim = [xymin - binsize, xymax + binsize]

--- a/modelskill/plot.py
+++ b/modelskill/plot.py
@@ -328,6 +328,28 @@ def _reglabel(slope: float, intercept: float) -> str:
     return f"Fit: y={slope:.2f}x{sign}{intercept:.2f}"
 
 
+def _get_bins(
+    bins: Union[int, float, Sequence[float]], xymin, xymax
+):  # TODO return type
+
+    assert xymax >= xymin
+    xyspan = xymax - xymin
+
+    if isinstance(bins, int):
+        nbins_hist = bins
+        binsize = xyspan / nbins_hist
+    elif isinstance(bins, float):
+        binsize = bins
+        nbins_hist = int(xyspan / binsize)
+    elif isinstance(bins, Sequence):
+        binsize = bins
+        nbins_hist = bins
+    else:
+        raise TypeError("bins must be an int, float or sequence")
+
+    return nbins_hist, binsize
+
+
 def scatter(
     x: np.ndarray,
     y: np.ndarray,
@@ -340,8 +362,8 @@ def scatter(
     show_density: Optional[bool] = None,
     backend: str = "matplotlib",
     figsize: Tuple[float, float] = (8, 8),
-    xlim: Optional[List[float]] = None,
-    ylim: Optional[List[float]] = None,
+    xlim: Optional[Tuple[float, float]] = None,
+    ylim: Optional[Tuple[float, float]] = None,
     reg_method: str = "ols",
     title: str = "",
     xlabel: str = "",
@@ -429,24 +451,13 @@ def scatter(
         else:
             quantiles = 10
 
-    xyspan = xymax - xymin
-    if isinstance(bins, int):
-        nbins_hist = bins
-        binsize = xyspan / nbins_hist
-    elif isinstance(bins, float):
-        binsize = bins
-        nbins_hist = int(xyspan / binsize)
-    elif isinstance(bins, Sequence):
-        binsize = bins
-        nbins_hist = bins
-    else:
-        raise TypeError("bins must be an int, float or sequence")
+    nbins_hist, binsize = _get_bins(bins, xymin=xymin, xymax=xymax)
 
     if xlim is None:
-        xlim = [xymin - binsize, xymax + binsize]
+        xlim = (xymin - binsize, xymax + binsize)
 
     if ylim is None:
-        ylim = [xymin - binsize, xymax + binsize]
+        ylim = (xymin - binsize, xymax + binsize)
 
     if isinstance(quantiles, int):
         xq = np.quantile(x, q=np.linspace(0, 1, num=quantiles))

--- a/tests/test_multimodelcompare.py
+++ b/tests/test_multimodelcompare.py
@@ -286,8 +286,6 @@ def test_mm_scatter(cc):
     cc.scatter(model="SW_2", show_points=False)
     cc.scatter(model="SW_2", show_hist=False)
     cc.scatter(model="SW_2", bins=0.5)
-    with pytest.warns(UserWarning, match="`binsize` and `nbins` are deprecated"):
-        cc.scatter(model="SW_2", nbins=5, reg_method="odr")
     cc.scatter(model="SW_2", title="t", xlabel="x", ylabel="y")
     cc.scatter(model="SW_2", show_points=True)
     cc.scatter(model="SW_2", show_points=100)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pytest
+
+from modelskill.plot import sample_points
+
+
+@pytest.fixture
+def x_y():
+    np.random.seed(42)
+    x = np.random.rand(100000)
+    y = np.random.rand(100000)
+    return x, y
+
+
+def test_sample_points_bool_selects_all_points(x_y):
+    x, y = x_y
+
+    x_sample, y_sample = sample_points(x, y, show_points=True)
+    assert len(x_sample) == len(x)
+    assert len(y_sample) == len(y)
+
+
+def test_sample_points_bool_selects_no_points(x_y):
+    x, y = x_y
+
+    x_sample, y_sample = sample_points(x, y, show_points=False)
+    assert len(x_sample) == 0
+    assert len(y_sample) == 0
+
+
+def test_sample_points_int_selects_n_points(x_y):
+    x, y = x_y
+
+    x_sample, y_sample = sample_points(x, y, show_points=10)
+    assert len(x_sample) == 10
+    assert len(y_sample) == 10
+
+
+def test_sample_points_float_selects_fraction_points(x_y):
+    x, y = x_y
+
+    x_sample, y_sample = sample_points(x, y, show_points=0.1)
+    assert len(x_sample) == 10000
+    assert len(y_sample) == 10000
+
+
+def test_sample_points_float_raises_error(x_y):
+    x, y = x_y
+
+    with pytest.raises(ValueError):
+        sample_points(x, y, show_points=1.1)
+
+    with pytest.raises(ValueError):
+        sample_points(x, y, show_points=-0.1)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -15,7 +15,7 @@ def x_y():
 def test_sample_points_bool_selects_all_points(x_y):
     x, y = x_y
 
-    x_sample, y_sample = sample_points(x, y, show_points=True)
+    x_sample, y_sample = sample_points(x, y, include=True)
     assert len(x_sample) == len(x)
     assert len(y_sample) == len(y)
 
@@ -23,7 +23,7 @@ def test_sample_points_bool_selects_all_points(x_y):
 def test_sample_points_bool_selects_no_points(x_y):
     x, y = x_y
 
-    x_sample, y_sample = sample_points(x, y, show_points=False)
+    x_sample, y_sample = sample_points(x, y, include=False)
     assert len(x_sample) == 0
     assert len(y_sample) == 0
 
@@ -31,7 +31,7 @@ def test_sample_points_bool_selects_no_points(x_y):
 def test_sample_points_int_selects_n_points(x_y):
     x, y = x_y
 
-    x_sample, y_sample = sample_points(x, y, show_points=10)
+    x_sample, y_sample = sample_points(x, y, include=10)
     assert len(x_sample) == 10
     assert len(y_sample) == 10
 
@@ -39,7 +39,7 @@ def test_sample_points_int_selects_n_points(x_y):
 def test_sample_points_float_selects_fraction_points(x_y):
     x, y = x_y
 
-    x_sample, y_sample = sample_points(x, y, show_points=0.1)
+    x_sample, y_sample = sample_points(x, y, include=0.1)
     assert len(x_sample) == 10000
     assert len(y_sample) == 10000
 
@@ -48,7 +48,22 @@ def test_sample_points_float_raises_error(x_y):
     x, y = x_y
 
     with pytest.raises(ValueError):
-        sample_points(x, y, show_points=1.1)
+        sample_points(x, y, include=1.1)
 
     with pytest.raises(ValueError):
-        sample_points(x, y, show_points=-0.1)
+        sample_points(x, y, include=-0.1)
+
+
+def test_sample_points_negative_int_raises_error(x_y):
+    x, y = x_y
+
+    with pytest.raises(ValueError):
+        sample_points(x, y, include=-1)
+
+
+def test_sample_points_large_int_uses_all_points(x_y):
+    x, y = x_y
+
+    x_sample, y_sample = sample_points(x, y, include=1000000)
+    assert len(x_sample) == len(x)
+    assert len(y_sample) == len(y)


### PR DESCRIPTION
The `scatter()` function is one of the key functions of `modelskill` and needs to be understandable.

This PR aims to refactor this long function into several more manageable functions, and to highlight differences between the matplotlib version and the plotly version.

And remove deprecated arguments `binsize` and `nbins`.