### PR TITLE
Added_z_comparison

### DIFF
--- a/modelskill/comparison.py
+++ b/modelskill/comparison.py
@@ -610,7 +610,6 @@ class Comparer:
         df["observation"] = self.name
         df["x"] = self.data.x
         df["y"] = self.data.y
-        df["z"] = self.data.z
         df["obs_val"] = self.obs
 
         return df

--- a/modelskill/comparison.py
+++ b/modelskill/comparison.py
@@ -560,6 +560,13 @@ class Comparer:
             return self.data["y"].values
 
     @property
+    def z(self):
+        if "z" in self.data[self._obs_name].attrs.keys():
+            return self.data[self._obs_name].attrs["z"]
+        else:
+            return self.data["z"].values
+        
+    @property
     def obs(self) -> np.ndarray:
         return self.data[self._obs_name].to_dataframe().values
 

--- a/modelskill/comparison.py
+++ b/modelskill/comparison.py
@@ -428,6 +428,7 @@ class Comparer:
         if gtype == "point":
             data["x"] = observation.x
             data["y"] = observation.y
+            data["z"] = observation.z
 
         data.attrs["name"] = observation.name
         # data.attrs["variable_name"] = observation.variable_name
@@ -602,6 +603,7 @@ class Comparer:
         df["observation"] = self.name
         df["x"] = self.data.x
         df["y"] = self.data.y
+        df["z"] = self.data.z
         df["obs_val"] = self.obs
 
         return df
@@ -656,6 +658,7 @@ class Comparer:
                 name=self.name,
                 x=self.x,
                 y=self.y,
+                z=self.z,
                 # variable_name=self.variable_name,
                 # units=self._unit_text,
             )


### PR DESCRIPTION
When creating a point comparer object, the user can specify (if he wants) x,y,z, and by default they are none.
For some reason in the comparison objects, then the values of `x,y` where being inherited, (if None, `None` was being inherited) but `z` dissapeared, for no reason.
I just added `z` just like `x` and `y`