### PR TITLE
Updated formatting of scatter plots

### DIFF
--- a/modelskill/comparison.py
+++ b/modelskill/comparison.py
@@ -29,7 +29,7 @@ from . import metrics as mtr
 from . import Quantity
 from . import __version__
 from .observation import Observation, PointObservation, TrackObservation
-from .plot import scatter, taylor_diagram, TaylorPoint
+from .plot import scatter, taylor_diagram, TaylorPoint, colors
 from .skill import AggregatedSkill
 from .spatial import SpatialSkill
 from .settings import options, register_option, reset_option
@@ -1101,6 +1101,7 @@ class Comparer:
         show_points: Union[bool, int, float] = None,
         show_hist: bool = None,
         show_density: bool = None,
+        norm: colors = None,
         backend: str = "matplotlib",
         figsize: List[float] = (8, 8),
         xlim: List[float] = None,
@@ -1144,8 +1145,11 @@ class Comparer:
             show the data density as a a 2d histogram, by default None
         show_density: bool, optional
             show the data density as a colormap of the scatter, by default None. If both `show_density` and `show_hist`
-        are None, then `show_density` is used by default.
+            are None, then `show_density` is used by default.
             for binning the data, the previous kword `bins=Float` is used
+        norm : matplotlib.colors norm
+            colormap normalization
+            If None, defaults to matplotlib.colors.PowerNorm(vmin=1,gamma=0.5)
         backend : str, optional
             use "plotly" (interactive) or "matplotlib" backend, by default "matplotlib"
         figsize : tuple, optional
@@ -1230,6 +1234,7 @@ class Comparer:
             show_points=show_points,
             show_hist=show_hist,
             show_density=show_density,
+            norm=norm,
             backend=backend,
             figsize=figsize,
             xlim=xlim,

--- a/modelskill/styles/mood.yml
+++ b/modelskill/styles/mood.yml
@@ -6,6 +6,7 @@ plot.scatter.legend.kwargs:
   bbox_to_anchor: [1.2,0.1]
   edgecolor: k
   loc: center left
+  frameon: True
 plot.scatter.oneone_line.color: darkorange
 plot.scatter.oneone_line.label: 1:1 (45°)
 plot.scatter.points.alpha: 0.9
@@ -20,3 +21,5 @@ plot.scatter.quantiles.markersize: 3.5
 plot.scatter.reg_line.kwargs:
   color: [0, 0.596078431372549, 0.8588235294117647]
   dashes: [2,5]
+plot.rcParams:
+  mathtext.default: regular


### PR DESCRIPTION
Aesthetic updates to modelskill plots:

- Skill table now uses normal font
- Unless specified, scatter defaults to `PowerNorm`
- Added `plot.rcParams` default to MOOD style (though still not automatically initialized)