### PR TITLE
custom metrics as series

### DIFF
--- a/modelskill/comparison.py
+++ b/modelskill/comparison.py
@@ -319,7 +319,7 @@ def _groupby_df(df, by, metrics, n_min: int = None):
         row = {}
         row["n"] = len(x)
         for metric in metrics:
-            row[metric.__name__] = metric(x.obs_val.values, x.mod_val.values)
+            row[metric.__name__] = metric(x.obs_val, x.mod_val)
         return pd.Series(row)
 
     # .drop(columns=["x", "y"])


### PR DESCRIPTION
Hi.
I just changed a single line. 
All tests still pass.
I am just changing metrics from a `numpy array` (so just values) to a pandas series. That way, the values are remain the same, but the time index is not lost.
This simple change allows me to calculate, for instance, the `Peak Ratio` metric, which requires `model data`, `measured data`, **and** time axis.