### PR TITLE
Filtering in scatter is deprecated, not removed

### DIFF
--- a/modelskill/comparison/_comparison.py
+++ b/modelskill/comparison/_comparison.py
@@ -1139,7 +1139,11 @@ class Comparer:
             "This method is deprecated, use plot.scatter instead", FutureWarning
         )
 
-        self.plot.scatter(
+        # TODO remove in v1.1
+        model, start, end, area = _get_deprecated_args(kwargs)
+
+        # self.plot.scatter(
+        self.sel(model=model, start=start, end=end, area=area,).plot.scatter(
             bins=bins,
             quantiles=quantiles,
             fit_to_quantiles=fit_to_quantiles,

--- a/tests/test_multimodelcompare.py
+++ b/tests/test_multimodelcompare.py
@@ -301,6 +301,12 @@ def test_mm_mean_skill_weights_dict(cc):
 def test_mm_scatter(cc):
 
     with pytest.warns(FutureWarning):
+        cc.scatter(start="2017-10-28")
+
+    with pytest.warns(FutureWarning):
+        cc[0].scatter(start="2017-10-28")
+
+    with pytest.warns(FutureWarning):
         cc.scatter()
 
     # scatter is the default plot


### PR DESCRIPTION
We want to make the upgrade process as painless as possible, so this shouldn't have been removed. Thanks to @daniel-caichac-DHI for pointing this out.