### PR TITLE
Pandas deprecations

### DIFF
--- a/modelskill/comparison/_collection_plotter.py
+++ b/modelskill/comparison/_collection_plotter.py
@@ -119,10 +119,11 @@ class ComparerCollectionPlotter:
             raise ValueError("No data found in selection")
 
         df = cmp.to_dataframe()
-        x = df.obs_val
-        y = df.mod_val
+        x = df.obs_val.values
+        y = df.mod_val.values
 
-        unit_text = self.cc[df.observation[0]].unit_text
+        # TODO why the first?
+        unit_text = self.cc[0].unit_text
 
         xlabel = xlabel or f"Observation, {unit_text}"
         ylabel = ylabel or f"Model, {unit_text}"
@@ -211,7 +212,10 @@ class ComparerCollectionPlotter:
             df_model = df[df.model == model]
             df_model.mod_val.plot.kde(ax=ax, label=model, **kwargs)
 
-        plt.xlabel(f"{self.cc[df.observation[0]].unit_text}")
+        # TODO use unit_text from the first comparer
+        # TODO make sure they are conistent
+        # then it should be a property of the collection, not only the comparer
+        plt.xlabel(f"{self.cc[0].unit_text}")
 
         # TODO title?
         ax.legend()

--- a/modelskill/comparison/_comparison.py
+++ b/modelskill/comparison/_comparison.py
@@ -298,7 +298,7 @@ def _groupby_df(df, by, metrics, n_min: Optional[int] = None):
 
     # .drop(columns=["x", "y"])
 
-    res = df.groupby(by=by).apply(calc_metrics)
+    res = df.groupby(by=by, observed=False).apply(calc_metrics)
 
     if n_min:
         # nan for all cols but n

--- a/modelskill/metrics.py
+++ b/modelskill/metrics.py
@@ -816,6 +816,7 @@ def _partial_duration_series(
     inter_time = inter_event_time
     inter_level = 1.0
     time = np.asarray(time)
+    value = np.asarray(value)
     time = (time - time[0]).astype(float) / 1e9 / 3600  # time index in hours from t0=0
 
     for time_step in range(n):

--- a/tests/test_comparer.py
+++ b/tests/test_comparer.py
@@ -567,10 +567,10 @@ def test_pc_to_dataframe(pc):
     assert df.y.dtype == "float64"
     assert df.model.dtype == "category"
     assert df.observation.dtype == "category"
-    assert df.x[0] == 10.0
-    assert df.y[0] == 55.0
-    assert df.model[0] == "m1"
-    assert df.model[9] == "m2"
+    assert df.iloc[0].x == 10.0
+    assert df.iloc[0].y == 55.0
+    assert df.iloc[0].model == "m1"
+    assert df.iloc[9].model == "m2"
 
 
 def test_pc_to_dataframe_add_col(pc):

--- a/tests/test_multimodelcompare.py
+++ b/tests/test_multimodelcompare.py
@@ -134,7 +134,7 @@ def test_mm_skill_obs(cc):
 
 def test_mm_mean_skill_obs(cc):
     df = cc.sel(model=0, observation=[0, "c2"]).mean_skill().df
-    assert pytest.approx(df.si[0]) == 0.11113215
+    assert pytest.approx(df.iloc[0].si) == 0.11113215
 
 
 def test_mm_skill_missing_obs(cc, o1):


### PR DESCRIPTION
Fix these two classes of warnings

* _FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]_
* _FutureWarning: The default of observed=False is deprecated and will be changed to True in a future version of pandas. Pass observed=False to retain current behavior or observed=True to adopt the future default and silence this warning._