### PR TITLE
rough solution kwargs metrics

### DIFF
--- a/modelskill/comparison/_collection.py
+++ b/modelskill/comparison/_collection.py
@@ -445,7 +445,7 @@ class ComparerCollection(Mapping):
         )  # len(df.variable.unique()) if (self.n_variables > 1) else 1
         by = _parse_groupby(by, n_models, n_obs, n_var)
 
-        res = _groupby_df(df.drop(columns=["x", "y"]), by, metrics)
+        res = _groupby_df(df.drop(columns=["x", "y"]), by, metrics, **kwargs)
         res = cmp._add_as_col_if_not_in_index(df, skilldf=res)
         return AggregatedSkill(res)
 

--- a/modelskill/comparison/_collection_plotter.py
+++ b/modelskill/comparison/_collection_plotter.py
@@ -133,9 +133,9 @@ class ComparerCollectionPlotter:
 
             # TODO why is this here?
             if isinstance(self, ComparerCollectionPlotter) and cmp.n_observations == 1:
-                skill_df = cmp.skill(metrics=metrics)
+                skill_df = cmp.skill(metrics=metrics,**kwargs)
             else:
-                skill_df = cmp.mean_skill(metrics=metrics)
+                skill_df = cmp.mean_skill(metrics=metrics,**kwargs)
             # TODO improve this
             try:
                 units = unit_text.split("[")[1].split("]")[0]

--- a/modelskill/comparison/_comparer_plotter.py
+++ b/modelskill/comparison/_comparer_plotter.py
@@ -508,7 +508,7 @@ class ComparerPlotter:
 
         if skill_table:
             metrics = None if skill_table is True else skill_table
-            skill_df = cmp.skill(metrics=metrics)
+            skill_df = cmp.skill(metrics=metrics,**kwargs)
             try:
                 units = unit_text.split("[")[1].split("]")[0]
             except IndexError:
@@ -518,7 +518,7 @@ class ComparerPlotter:
             # hide quantiles and regression line
             quantiles = 0
             reg_method = False
-
+        
         ax = scatter(
             x=x,
             y=y,

--- a/modelskill/comparison/_utils.py
+++ b/modelskill/comparison/_utils.py
@@ -61,12 +61,12 @@ def _add_spatial_grid_to_df(
     return df
 
 
-def _groupby_df(df, by, metrics, n_min: Optional[int] = None):
+def _groupby_df(df, by, metrics, n_min: Optional[int] = None , **kwargs):
     def calc_metrics(x):
         row = {}
         row["n"] = len(x)
         for metric in metrics:
-            row[metric.__name__] = metric(x.obs_val, x.mod_val)
+            row[metric.__name__] = metric(x.obs_val, x.mod_val , **kwargs)
         return pd.Series(row)
 
     # .drop(columns=["x", "y"])

--- a/modelskill/metrics.py
+++ b/modelskill/metrics.py
@@ -503,17 +503,22 @@ def explained_variance(obs: np.ndarray, model: np.ndarray) -> float:
     return nominator / denominator
 
 
-def pr(obs: np.ndarray, model: np.ndarray) -> float:
+def pr(obs: np.ndarray, model: np.ndarray, inter_event_level: float = 0.7, AAP: int = 2) -> float:
     """alias for peak_ratio"""
     assert obs.size == model.size
-    return peak_ratio(obs, model)
+    return peak_ratio(obs, model, inter_event_level, AAP)
 
 
-def peak_ratio(obs: pd.Series, model: pd.Series) -> float:
+def peak_ratio(obs: pd.Series, model: pd.Series, inter_event_level: float = 0.7, AAP: int = 2) -> float:
     """Peak Ratio
 
     PR is the ratio of the mean of the identified peaks in the
     model / identified peaks in the measurements
+
+    inter_event_level (float, optional)
+        Inter-event level threshold (default: 0.7).
+    AAP (float, optional)
+        Average Annual Peaks (ie, Number of peaks per year, on average). (default: 2)
 
     .. math::
             \\frac{\\sum_{i=1}^{N_{peak}} (model_i)}{\\sum_{i=1}^{N_{peak}} (obs_i)}
@@ -533,11 +538,11 @@ def peak_ratio(obs: pd.Series, model: pd.Series) -> float:
     N_years = dt_int_mode / 24 / 3600 / 365.25 * len(time)
     found_peaks = []
     for data in [obs, model]:
-        peak_index, AAP = _partial_duration_series(time, data)
+        peak_index, AAP_ = _partial_duration_series(time, data, inter_event_level=inter_event_level, AAP=AAP)
         peaks = data[peak_index]
         peaks_sorted = peaks.sort_values(ascending=False)
         found_peaks.append(
-            peaks_sorted[0 : max(1, min(round(AAP * N_years), np.sum(peaks)))]
+            peaks_sorted[0 : max(1, min(round(AAP_ * N_years), np.sum(peaks)))]
         )
     found_peaks_obs = found_peaks[0]
     found_peaks_mod = found_peaks[1]
@@ -775,6 +780,7 @@ def add_metric(metric: Callable, has_units: bool = False) -> None:
 def _partial_duration_series(
     time,
     value,
+    *,
     inter_event_time=36,
     use_inter_event_level=True,
     inter_event_level=0.7,
@@ -908,3 +914,6 @@ def _partial_duration_series(
                     old_peak = i
         i += 1
     return peak_list.astype(bool), AAP
+
+def _allowed_kwargs():
+    return ['inter_event_time','use_inter_event_level','inter_event_level','AAP','a','weights','unbiased']

--- a/modelskill/plotting/_scatter.py
+++ b/modelskill/plotting/_scatter.py
@@ -17,7 +17,7 @@ from scipy import interpolate
 import modelskill.settings as settings
 from modelskill.settings import options
 
-from ..metrics import _linear_regression
+from ..metrics import _linear_regression, _allowed_kwargs
 from ._misc import quantiles_xy, sample_points, format_skill_df, _get_fig_ax
 
 
@@ -169,6 +169,8 @@ def scatter(
 
     if backend not in PLOTTING_BACKENDS:
         raise ValueError(f"backend must be one of {list(PLOTTING_BACKENDS.keys())}")
+    
+    kwargs={k:v for (k,v) in kwargs.items() if k not in _allowed_kwargs()}
 
     return PLOTTING_BACKENDS[backend](
         x=x,


### PR DESCRIPTION
Hi,

I added a few lines that allow to add kword before doing skill and plotting, eg

`cmp=modelskill.compare(mod=mod,obs=obs)`
`cmp.skill( metrics=['bias','pr'], AAP=7)`
but also
`cmp.plot.scatter (metrics=['bias','pr'], AAP=7)` 

Please suggest some tests to make this a thing.
Also my solution is a little bit rough in the sense that I had to make a list of allowed kwargs to split between the .skill and the .plot (since in plotting we also have kwargs but if you try to add `AAP=7` to matplotlib plot it will crash).

See 
https://github.com/DHI/modelskill/issues/289