### PR TITLE
Observation attrs container

### DIFF
--- a/tests/observation/test_point_obs.py
+++ b/tests/observation/test_point_obs.py
@@ -7,7 +7,7 @@ import modelskill as ms
 
 @pytest.fixture
 def klagshamn_filename():
-    return "tests/testdata/smhi_2095_klagshamn.dfs0"
+    return "tests/testdata/smhi_2095_klagshamn_200.dfs0"
 
 
 @pytest.fixture
@@ -31,7 +31,7 @@ def test_from_dfs0(klagshamn_filename):
     o1 = ms.PointObservation(
         klagshamn_filename, item=0, x=366844, y=6154291, name="Klagshamn"
     )
-    assert o1.n_points == 50328
+    assert o1.n_points == 198  # 200 including 2 NaN
 
     o2 = ms.PointObservation(
         klagshamn_filename, item="Water Level", x=366844, y=6154291
@@ -123,3 +123,10 @@ def test_point_data_can_be_persisted_as_netcdf(klagshamn_filename, tmp_path):
     p = ms.PointObservation(klagshamn_filename)
 
     p.data.to_netcdf(tmp_path / "test.nc")
+
+
+def test_attrs(klagshamn_filename):
+    o1 = ms.PointObservation(
+        klagshamn_filename, item=0, attrs={"a1": "v1"}, name="Klagshamn"
+    )
+    assert o1.data.attrs["a1"] == "v1"


### PR DESCRIPTION
Allowing users to store arbitrary meta data. The data will be carried over to the Comparer object. 

Could allow user to filter in ComparerCollection (e.g. taking all DA stations only). And could allow user to access meta data e.g. for plot title etc.