### PR TITLE
Unit handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ modelskill/*.bak
 notebooks/sandbox.ipynb
 streamlit_app.py
 notes.md
+
+notebooks/Untitled.ipynb

--- a/modelskill/model/grid.py
+++ b/modelskill/model/grid.py
@@ -72,7 +72,18 @@ class GridModelResult(SpatialField):
 
         self.data: xr.DataArray = ds[item_name]
         self.name = name
-        self.quantity = quantity or Quantity.undefined()
+
+        # use long_name and units from data if not provided
+        if quantity is None:
+            if self.data.attrs.get("long_name") and self.data.attrs.get("units"):
+                quantity = Quantity(
+                    name=self.data.attrs["long_name"],
+                    unit=self.data.attrs["units"],
+                )
+            else:
+                quantity = Quantity.undefined()
+
+        self.quantity = quantity
 
     @property
     def time(self) -> pd.DatetimeIndex:

--- a/modelskill/types.py
+++ b/modelskill/types.py
@@ -155,7 +155,7 @@ class Quantity:
 
     @staticmethod
     def undefined() -> "Quantity":
-        return Quantity(name="Undefined", unit="Undefined")
+        return Quantity(name="", unit="")
 
     def to_dict(self) -> Dict[str, str]:
         return {"name": self.name, "unit": self.unit}

--- a/tests/model/test_grid.py
+++ b/tests/model/test_grid.py
@@ -50,13 +50,15 @@ def test_grid_from_nc(mr_ERA5_pp1d):
 
 def test_grid_from_DataArray(ERA5_DutchCoast_nc):
     ds = xr.open_dataset(ERA5_DutchCoast_nc)
-    mr = ms.ModelResult(ds["swh"])
+    mr = ms.GridModelResult(ds["swh"])
+    assert mr.quantity.name == "Significant height of combined wind waves and swell"
+    assert mr.quantity.unit == "m"
 
-    assert isinstance(mr, ms.GridModelResult)
-
-    # TODO get quantity info from nc
-    # assert mr.quantity.name == "Significant Wave Height"
-    assert mr.quantity.name == "Undefined"
+    mr2 = ms.GridModelResult(
+        ds["swh"], quantity=ms.Quantity("Significant height", unit="meter")
+    )
+    assert mr2.quantity.name == "Significant height"
+    assert mr2.quantity.unit == "meter"
 
 
 def test_dataset_with_missing_coordinates(ERA5_DutchCoast_nc):

--- a/tests/test_comparer.py
+++ b/tests/test_comparer.py
@@ -91,8 +91,6 @@ def test_matched_df(pt_df):
     assert len(cmp.mod_names) == 2
     assert cmp.n_points == 6
     assert cmp.name == "Observation"
-    assert cmp.quantity.name == "Undefined"
-    assert cmp.quantity.unit == "Undefined"
 
 
 def test_matched_df_int_items(pt_df):
@@ -122,8 +120,6 @@ def test_matched_df_with_aux(pt_df):
     assert set(cmp.mod_names) == set(["m1", "m2", "wind", "not_relevant"])
     assert cmp.n_points == 6
     assert cmp.name == "Observation"
-    assert cmp.quantity.name == "Undefined"
-    assert cmp.quantity.unit == "Undefined"
     assert cmp.data["wind"].attrs["kind"] == "model"
 
     # but it can be specified
@@ -215,14 +211,10 @@ def test_minimal_matched_data(pt_df):
     cmp = Comparer.from_matched_data(data=data)  # no additional raw_mod_data
 
     assert cmp.data["Observation"].attrs["color"] == "black"
-    assert cmp.data["Observation"].attrs["units"] == "Undefined"
-    assert cmp.data["Observation"].attrs["long_name"] == "Undefined"
     assert len(cmp.raw_mod_data["m1"]) == 6
 
     assert cmp.mod_names == ["m1", "m2"]
     assert cmp.n_models == 2
-    assert cmp.quantity.name == "Undefined"
-    assert cmp.quantity.unit == "Undefined"
 
 
 def test_from_compared_data_doesnt_accept_missing_values_in_obs():


### PR DESCRIPTION
If I don't care about the units (no quantity info added), I prefer to not have "Undefined" in the skill table.

This PR makes the skill table a bit cleaner 
![image](https://github.com/DHI/modelskill/assets/614215/7bcee311-08d5-40cb-ac49-fdb5c15d1a50)

And as bonus I throw in reading of conventional attributes [`long_name` and `units`](https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/ch03.html)