### PR TITLE
Deprecate `Connector`

### DIFF
--- a/modelskill/connection.py
+++ b/modelskill/connection.py
@@ -69,8 +69,6 @@ def _config_to_yml(filename, conf):
 
 
 class SingleObsConnector:
-    """A connection between a single observation and model(s)"""
-
     def __repr__(self):
         if self.n_models > 0:
             obs_txt = f"obs={self.name}(n={self.obs.n_points})"
@@ -87,6 +85,12 @@ class SingleObsConnector:
         return f"<{self.__class__.__name__}> {txt}"
 
     def __init__(self, obs, mod, weight=1.0, validate=True):
+        # deprecated
+        warnings.warn(
+            FutureWarning(
+                "SingleObsConnector is deprecated! Use `modelskill.compare` instead"
+            )
+        )
         self.obs = None
         obs = self._parse_observation(obs)
         self.name = obs.name
@@ -198,36 +202,6 @@ class SingleObsConnector:
 
 
 class Connector(Sequence):
-    """The Connector is used for matching Observations and ModelResults
-
-    It is one of the most important classes in modelskill. The connections are
-    added either at construction of the Connector or by using the add()
-    method.
-
-    When observations and modelResults are added the connection is
-    validated (inside domain? overlapping time? eum match?).
-
-    The extract() method are then called to extract ModelResult data at
-    the time and positions of each observation.
-
-    Note
-    ----
-    Only ModelResults with a single item can be added to the Connector.
-    From a multi-item ModelResult 'mr' an item must selected e.g. with
-    'mr[0]' before adding
-
-    Examples
-    --------
-    >>> mr = ModelResult("Oresund2D.dfsu", item=0)
-    >>> o1 = PointObservation("Drogden_Fyr.dfs0", item=0, x=355568., y=6156863.)
-    >>> o2 = TrackObservation(df, item=2, name="altimeter")
-    >>> conA = Connector([o1, o2], mr)
-    >>> conB = Connector()
-    >>> conB.add(o1, mr)
-    >>> conB.add(o2, mr)    # conA = conB
-    >>> cc = conB.extract()
-    """
-
     @property
     def n_observations(self):
         """Number of (unique) observations in Connector."""
@@ -253,6 +227,10 @@ class Connector(Sequence):
         return txt + "\n".join(" -" + repr(c) for c in self.connections.values())
 
     def __init__(self, obs=None, mod=None, weight=1.0, validate=True):
+        warnings.warn(
+            FutureWarning("Connector is deprecated! Use `modelskill.compare` instead")
+        )
+
         self.name = None
         self.connections = {}
         self.observations = {}

--- a/tests/model/test_dfsu.py
+++ b/tests/model/test_dfsu.py
@@ -138,7 +138,6 @@ def test_dfsu_factory(hd_oresund_2d):
 #         _ = mr.extract_observation(wind_HKNA)
 
 
-# TODO: move this test to test_connector.py
 def test_extract_observation_total_windsea_swell_not_possible(
     sw_total_windsea, Hm0_HKNA
 ):
@@ -158,26 +157,23 @@ def test_extract_observation_total_windsea_swell_not_possible(
     assert cc.n_points > 0
 
 
-# TODO: move this test to test_connector.py
 def test_extract_observation_validation(hd_oresund_2d, klagshamn):
     mr = ms.ModelResult(hd_oresund_2d, item=0)
     with pytest.raises(Exception):
         c = ms.Connector(klagshamn, mr, validate=True).extract()
 
     # No error if validate==False
-    c = ms.Connector(klagshamn, mr, validate=False).extract()
+    with pytest.warns(FutureWarning, match="modelskill.compare"):
+        c = ms.Connector(klagshamn, mr, validate=False).extract()
     assert c.n_points > 0
 
 
-# TODO: move this test to test_connector.py
 def test_extract_observation_outside(hd_oresund_2d, klagshamn):
     mr = ms.ModelResult(hd_oresund_2d, item=0)
     # correct eum, but outside domain
     klagshamn.y = -10
     with pytest.raises(ValueError):
         _ = ms.Connector(klagshamn, mr, validate=True).extract()
-
-        # _ = mr.extract_observation(klagshamn, validate=True)
 
 
 def test_dfsu_extract_point(sw_dutch_coast, Hm0_EPL):

--- a/tests/test_combine_comparers.py
+++ b/tests/test_combine_comparers.py
@@ -47,28 +47,6 @@ def o123():
     return o1, o2, o3
 
 
-# def test_concat_time(o123, mr28, mr29, mr2days):
-#     con1 = ms.Connector(o123, mr28)
-#     with pytest.warns(UserWarning, match="No overlapping data"):
-#         cc1 = con1.extract()
-#     # cc1 = ms.compare(o123, mr28)
-#     cc2 = ms.compare(o123, mr29)
-
-#     # Note: the multi-file dataset will have interpolated values
-#     # between 23:00 the first day and 00:00 the second day
-#     # that is NOT the case with the concatenated cc12b
-#     cc12 = ms.compare(o123, mr2days)
-
-#     assert cc1.start == cc12.start
-#     assert cc2.end == cc12.end
-
-#     cc12b = cc1 + cc2
-#     assert cc1.start == cc12b.start
-#     assert cc2.end == cc12b.end
-#     assert cc12b.n_points < cc12.n_points
-#     assert cc12b.n_points == cc1.n_points + cc2.n_points
-
-
 def test_concat_model(o123, mrmike, mrmike2):
     cc1 = ms.compare(o123, mrmike)
     cc2 = ms.compare(o123, mrmike2)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -43,22 +43,26 @@ def o3():
 
 @pytest.fixture
 def con31(o1, o2, o3, mr1):
-    return ms.Connector([o1, o2, o3], mr1)
+    with pytest.warns(FutureWarning, match="modelskill.compare"):
+        return ms.Connector([o1, o2, o3], mr1)
 
 
 @pytest.fixture
 def con32(o1, o2, o3, mr1, mr2):
-    return ms.Connector([o1, o2, o3], [mr1, mr2])
+    with pytest.warns(FutureWarning, match="modelskill.compare"):
+        return ms.Connector([o1, o2, o3], [mr1, mr2])
 
 
 def test_point_connector_repr(o1, mr1):
-    con = SingleObsConnector(o1, mr1)
+    with pytest.warns(FutureWarning, match="modelskill.compare"):
+        con = SingleObsConnector(o1, mr1)
     txt = repr(con)
     assert "SingleObsConnector" in txt
 
 
 def test_connector_add(o1, mr1):
-    con = ms.Connector()
+    with pytest.warns(FutureWarning, match="modelskill.compare"):
+        con = ms.Connector()
     con.add(o1, mr1, validate=False)
     assert len(con.observations) == 1
 
@@ -66,14 +70,16 @@ def test_connector_add(o1, mr1):
 def test_connector_add_two_models(
     o1: ms.PointObservation, mr1: ms.ModelResult, mr2: ms.ModelResult
 ):
-    con = ms.Connector(o1, [mr1, mr2])
+    with pytest.warns(FutureWarning, match="modelskill.compare"):
+        con = ms.Connector(o1, [mr1, mr2])
 
     assert con.n_models == 2
     cc = con.extract()
     assert cc.n_models == 2
 
     # Alternative specification using .add() should be identical
-    con2 = ms.Connector()
+    with pytest.warns(FutureWarning, match="modelskill.compare"):
+        con2 = ms.Connector()
     con2.add(o1, mr1)
     con2.add(o1, mr2)
 
@@ -97,25 +103,19 @@ def test_connector_add_two_model_dataframes(
     assert mr1_extr.n_points > 1  # Number of rows
     assert mr2_extr.n_points > 1  # Number of rows
 
-    con = ms.Connector(o1, [mr1_extr, mr2_extr])
+    with pytest.warns(FutureWarning, match="modelskill.compare"):
+        con = ms.Connector(o1, [mr1_extr, mr2_extr])
 
     assert con.n_models == 2
     cc = con.extract()
     assert cc.n_models == 2
 
     # Alternative specification using .add() should be identical
-    con2 = ms.Connector()
+    with pytest.warns(FutureWarning, match="modelskill.compare"):
+        con2 = ms.Connector()
     con2.add(o1, mr1_extr)
     con2.add(o1, mr2_extr)
 
     assert con2.n_models == 2
     cc2 = con2.extract()
     assert cc2.n_models == 2
-
-
-def test_plot_positions(con32):
-    con32.plot_observation_positions()
-
-
-def test_plot_data_coverage(con31):
-    con31.plot_temporal_coverage()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -63,7 +63,7 @@ def test_point_connector_repr(o1, mr1):
 def test_connector_add(o1, mr1):
     with pytest.warns(FutureWarning, match="modelskill.compare"):
         con = ms.Connector()
-    con.add(o1, mr1, validate=False)
+        con.add(o1, mr1, validate=False)
     assert len(con.observations) == 1
 
 
@@ -80,8 +80,8 @@ def test_connector_add_two_models(
     # Alternative specification using .add() should be identical
     with pytest.warns(FutureWarning, match="modelskill.compare"):
         con2 = ms.Connector()
-    con2.add(o1, mr1)
-    con2.add(o1, mr2)
+        con2.add(o1, mr1)
+        con2.add(o1, mr2)
 
     assert con2.n_models == 2
     cc2 = con2.extract()
@@ -113,8 +113,8 @@ def test_connector_add_two_model_dataframes(
     # Alternative specification using .add() should be identical
     with pytest.warns(FutureWarning, match="modelskill.compare"):
         con2 = ms.Connector()
-    con2.add(o1, mr1_extr)
-    con2.add(o1, mr2_extr)
+        con2.add(o1, mr1_extr)
+        con2.add(o1, mr2_extr)
 
     assert con2.n_models == 2
     cc2 = con2.extract()

--- a/tests/test_connector_conf.py
+++ b/tests/test_connector_conf.py
@@ -33,59 +33,9 @@ def o3():
     return ms.TrackObservation(fn, item=3, name="c2")
 
 
-# @pytest.fixture
-# def con32(o1, o2, o3, mr1, mr2):
-#     return ms.Connector([o1, o2, o3], [mr1, mr2])
-
-
 @pytest.fixture
 def conf_xlsx():
     return "tests/testdata/SW/conf_SW.xlsx"
-
-
-# Exporting a connector to a config file, doesn't work if the data came from in memory objects
-
-# #def test_tofrom_config_dict(con32):
-#   d = con32.to_config()
-#     assert "modelresults" in d
-#     assert len(d["modelresults"]) == 2
-#     assert "observations" in d
-#     assert len(d["observations"]) == 3
-
-#     con = Connector.from_config(d)
-#     assert con.n_models == 2
-#     assert con.n_observations == 3
-#     assert len(con) == 3
-
-
-# def test_tofrom_config_yml(tmpdir, con32):
-#     filename = os.path.join(tmpdir.dirname, "testconf.yml")
-#     con32.to_config(filename, relative_path=False)
-#     d = Connector._yaml_to_dict(filename)
-#     assert "modelresults" in d
-#     assert len(d["modelresults"]) == 2
-#     assert "observations" in d
-#     assert len(d["observations"]) == 3
-
-#     con = Connector.from_config(filename, relative_path=False)
-#     assert con.n_models == 2
-#     assert con.n_observations == 3
-#     assert len(con) == 3
-
-
-# def test_tofrom_config_xlsx(tmpdir, con32):
-#     filename = os.path.join(tmpdir.dirname, "testconf.xlsx")
-#     con32.to_config(filename, relative_path=False)
-#     d = Connector._excel_to_dict(filename)
-#     assert "modelresults" in d
-#     assert len(d["modelresults"]) == 2
-#     assert "observations" in d
-#     assert len(d["observations"]) == 3
-
-#     con = Connector.from_config(filename, relative_path=False)
-#     assert con.n_models == 2
-#     assert con.n_observations == 3
-#     assert len(con) == 3
 
 
 def test_from_excel_include(conf_xlsx):
@@ -93,20 +43,3 @@ def test_from_excel_include(conf_xlsx):
     assert con.n_models == 1
     assert con.n_observations == 3
     assert len(con) == 3
-
-
-# def test_from_excel_save_new_relative(conf_xlsx):
-#     con = ms.from_config(conf_xlsx, relative_path=True)
-#     assert con.n_models == 1
-#     assert con.n_observations == 3
-#     assert len(con) == 3
-
-#     # I know you can use tmpdir, but it is not located in a very interpretable relative path...
-#     os.makedirs("tests/testdata/tmp/", exist_ok=True)
-#     fn = "tests/testdata/tmp/conf_SW.xlsx"
-#     con.to_config(fn)
-#     ms.from_config(fn)
-#     fn = "tests/testdata/tmp/conf_SW.yml"
-#     con.to_config(fn)
-#     con3 = ms.from_config(fn)
-#     assert os.path.exists(con3.observations["HKNA"].filename)

--- a/tests/test_pointcompare.py
+++ b/tests/test_pointcompare.py
@@ -90,7 +90,8 @@ def test_extraction_no_overlap(modelresult_oresund_WL):
     )
     mr = modelresult_oresund_WL
 
-    con = ms.Connector(o1, mr, validate=False)
+    with pytest.warns(FutureWarning, match="modelskill.compare"):
+        con = ms.Connector(o1, mr, validate=False)
     with pytest.raises(ValueError, match="No data"):
         con.extract()
 

--- a/tests/test_trackcompare.py
+++ b/tests/test_trackcompare.py
@@ -386,7 +386,7 @@ def test_df_input(obs_tiny_df, mod_tiny3):
     assert len(obs_tiny_df["2017-10-27 13:00:02":"2017-10-27 13:00:02"]) == 2
     with pytest.warns(UserWarning, match="Removed 2 duplicate timestamps"):
         cmp = ms.compare(obs_tiny_df, mod_tiny3, gtype="track")[0]
-    
+
     assert (
         cmp.data.sel(
             time=slice("2017-10-27 13:00:02", "2017-10-27 13:00:02")


### PR DESCRIPTION
With the ambition to retire it completely in a future version.