### PR TITLE
Working `See also` links in documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,3 +44,7 @@ plugins:
           show_source: True
           heading_level: 2
           docstring_style: "numpy" # default is google
+        import:
+          - https://docs.scipy.org/doc/numpy/objects.inv
+          - https://pandas.pydata.org/pandas-docs/stable/objects.inv
+          - https://matplotlib.org/stable/objects.inv

--- a/modelskill/comparison/_collection.py
+++ b/modelskill/comparison/_collection.py
@@ -435,7 +435,7 @@ class ComparerCollection(Mapping):
 
         See also
         --------
-        sel
+        [sel][modelskill.comparison.ComparerCollection.sel]:
             a method for filtering/selecting data
 
         Examples
@@ -546,7 +546,7 @@ class ComparerCollection(Mapping):
 
         See also
         --------
-        skill
+        [skill][modelskill.comparison.ComparerCollection.skill]:
             a method for aggregated skill assessment
 
         Examples
@@ -702,9 +702,9 @@ class ComparerCollection(Mapping):
 
         See also
         --------
-        skill
+        [skill][modelskill.comparison.ComparerCollection.skill]:
             skill assessment per observation
-        mean_skill_points
+        [mean_skill_points][modelskill.comparison.ComparerCollection.mean_skill_points]:
             skill assessment pooling all observation points together
 
         Examples
@@ -800,9 +800,9 @@ class ComparerCollection(Mapping):
 
         See also
         --------
-        skill
+        [skill][modelskill.comparison.ComparerCollection.skill]:
             skill assessment per observation
-        mean_skill
+        [mean_skill][modelskill.comparison.ComparerCollection.mean_skill]:
             weighted mean of skills (not the same as this method)
 
         Examples
@@ -927,11 +927,11 @@ class ComparerCollection(Mapping):
 
         See also
         --------
-        skill
+        [skill][modelskill.comparison.ComparerCollection.skill]:
             skill assessment per observation
-        mean_skill
+        [mean_skill][modelskill.comparison.ComparerCollection.mean_skill]:
             weighted mean of skills assessment
-        mean_skill_points
+        [mean_skill_points][modelskill.comparison.ComparerCollection.mean_skill_points]:
             skill assessment pooling all observation points together
 
         Examples

--- a/modelskill/comparison/_collection_plotter.py
+++ b/modelskill/comparison/_collection_plotter.py
@@ -281,8 +281,8 @@ class ComparerCollectionPlotter:
 
         See also
         --------
-        pandas.Series.hist
-        matplotlib.axes.Axes.hist
+        [pandas.Series.hist][]
+        [matplotlib.axes.Axes.hist][]
         """
         from ._comparison import MOD_COLORS
 

--- a/modelskill/comparison/_comparer_plotter.py
+++ b/modelskill/comparison/_comparer_plotter.py
@@ -164,8 +164,8 @@ class ComparerPlotter:
 
         See also
         --------
-        pandas.Series.plot.hist
-        matplotlib.axes.Axes.hist
+        [pandas.Series.plot.hist][]
+        [matplotlib.axes.Axes.hist][]
         """
         from ._comparison import MOD_COLORS  # TODO move to here
 
@@ -231,7 +231,7 @@ class ComparerPlotter:
 
         See also
         --------
-        pandas.Series.plot.kde
+        [pandas.Series.plot.kde][]
         """
         cmp = self.comparer
 
@@ -377,8 +377,8 @@ class ComparerPlotter:
 
         See also
         --------
-        pandas.DataFrame.boxplot
-        matplotlib.pyplot.boxplot
+        [pandas.DataFrame.boxplot][]
+        [matplotlib.pyplot.boxplot][]
         """
         cmp = self.comparer
 

--- a/modelskill/comparison/_comparison.py
+++ b/modelskill/comparison/_comparison.py
@@ -378,7 +378,7 @@ class Comparer:
 
     See Also
     --------
-    modelskill.compare, modelskill.from_matched
+    [modelskill.compare][], [modelskill.from_matched][]
     """
 
     data: xr.Dataset
@@ -931,7 +931,7 @@ class Comparer:
 
         See also
         --------
-        sel
+        [sel][modelskill.Comparer.sel]:
             a method for filtering/selecting data
 
         Examples
@@ -1003,7 +1003,7 @@ class Comparer:
 
         See also
         --------
-        skill
+        [skill][modelskill.Comparer.skill]:
             a method for skill assessment returning a pd.DataFrame
 
         Examples
@@ -1077,7 +1077,7 @@ class Comparer:
 
         See also
         --------
-        skill
+        [skill][modelskill.Comparer.skill]:
             a method for aggregated skill assessment
 
         Examples

--- a/modelskill/metrics.py
+++ b/modelskill/metrics.py
@@ -170,7 +170,7 @@ def urmse(
 
     See Also
     --------
-    root_mean_squared_error
+    [root_mean_squared_error][modelskill.metrics.root_mean_squared_error]
     """
     return root_mean_squared_error(obs, model, weights, unbiased=True)
 
@@ -357,8 +357,8 @@ def model_efficiency_factor(obs: np.ndarray, model: np.ndarray) -> float:
 
     See Also
     --------
-    nash_sutcliffe_efficiency
-    root_mean_squared_error
+    [nash_sutcliffe_efficiency][modelskill.metrics.nash_sutcliffe_efficiency]
+    [root_mean_squared_error][modelskill.metrics.root_mean_squared_error]
 
     """
     assert obs.size == model.size
@@ -384,8 +384,8 @@ def corrcoef(obs, model, weights=None) -> float:
 
     See Also
     --------
-    spearmanr
-    np.corrcoef
+    [spearmanr][modelskill.metrics.spearmanr]
+    [np.corrcoef][]
     """
     assert obs.size == model.size
     if len(obs) <= 1:
@@ -428,7 +428,7 @@ def spearmanr(obs: np.ndarray, model: np.ndarray) -> float:
 
     See Also
     --------
-    corrcoef
+    [corrcoef][modelskill.metrics.corrcoef]
     """
     import scipy.stats
 
@@ -507,7 +507,7 @@ def explained_variance(obs: np.ndarray, model: np.ndarray) -> float:
 
     See Also
     --------
-    r2
+    [r2][modelskill.metrics.r2]
     """
 
     assert obs.size == model.size

--- a/modelskill/plotting/_spatial_overview.py
+++ b/modelskill/plotting/_spatial_overview.py
@@ -34,7 +34,7 @@ def spatial_overview(
 
     See Also
     --------
-    temporal_coverage
+    [modelskill.plotting.temporal_coverage][]
 
     Returns
     -------

--- a/modelskill/plotting/_temporal_coverage.py
+++ b/modelskill/plotting/_temporal_coverage.py
@@ -42,7 +42,7 @@ def temporal_coverage(
 
     See Also
     --------
-    spatial_overview
+    [modelskill.plotting.spatial_overview][]
 
     Returns
     -------


### PR DESCRIPTION
Links to other part of the source code now works as expected.

The minor drawback is that the syntax looks sligthly less clean 
![image](https://github.com/DHI/modelskill/assets/614215/3479a280-93e6-4096-a799-4ae8da3beabd)
