### PR TITLE
Change categorical index to float

### DIFF
--- a/modelskill/comparison/_collection.py
+++ b/modelskill/comparison/_collection.py
@@ -618,6 +618,7 @@ class ComparerCollection(Mapping):
             end=end,
             area=area,
         )
+
         if cmp.n_points == 0:
             warnings.warn("No data!")
             return
@@ -635,7 +636,12 @@ class ComparerCollection(Mapping):
 
         df = df.drop(columns=["x", "y"]).rename(columns=dict(xBin="x", yBin="y"))
         res = _groupby_df(df, by, metrics, n_min)
-        return SkillGrid(res.to_xarray().squeeze())
+        ds = res.to_xarray().squeeze()
+
+        # change categorial index to coordinates
+        for dim in ("x", "y"):
+            ds[dim] = ds[dim].astype(float)
+        return SkillGrid(ds)
 
     def scatter(
         self,

--- a/modelskill/comparison/_comparison.py
+++ b/modelskill/comparison/_comparison.py
@@ -1157,7 +1157,13 @@ class Comparer:
 
         df = df.drop(columns=["x", "y"]).rename(columns=dict(xBin="x", yBin="y"))
         res = _groupby_df(df, by, metrics, n_min)
-        return SkillGrid(res.to_xarray().squeeze())
+        ds = res.to_xarray().squeeze()
+
+        # change categorial index to coordinates
+        for dim in ("x", "y"):
+            ds[dim] = ds[dim].astype(float)
+
+        return SkillGrid(ds)
 
     @property
     def residual(self):

--- a/tests/test_grid_skill.py
+++ b/tests/test_grid_skill.py
@@ -69,6 +69,16 @@ def test_gridded_skill_multi_model(cc2) -> None:
     assert len(ss.field_names) == 3
 
 
+def test_gridded_skill_is_subsettable(cc2) -> None:
+    ss = cc2.gridded_skill(bins=3, metrics=["rmse", "bias"])
+    ss.data.rmse.sel(x=2, y=53.5, method="nearest").values == pytest.approx(0.10411702)
+
+    cmp = cc2[0]
+
+    ss2 = cmp.gridded_skill(bins=3, metrics=["rmse", "bias"])
+    ss2.data.rmse.sel(x=2, y=53.5, method="nearest").values == pytest.approx(0.10411702)
+
+
 def test_gridded_skill_plot(cmp1) -> None:
     ss = cmp1.gridded_skill(metrics=["rmse", "bias"])
     ss.bias.plot()


### PR DESCRIPTION
It is not possible to select nearest point or interp in a categorical index (categories are not sorted).