### PR TITLE
Observation factory function

### DIFF
--- a/modelskill/__init__.py
+++ b/modelskill/__init__.py
@@ -28,7 +28,7 @@ from .quantity import Quantity
 from .model.factory import ModelResult
 from .model import model_result
 from .model import PointModelResult, TrackModelResult, GridModelResult, DfsuModelResult
-from .observation import PointObservation, TrackObservation
+from .observation import observation, PointObservation, TrackObservation
 from .matching import compare, from_matched, match
 from .connection import Connector
 from .configuration import from_config
@@ -61,17 +61,18 @@ def load(filename: Union[str, Path]) -> ComparerCollection:
 
 __all__ = [
     "Quantity",
-    "ModelResult",
+    "model_result",
     "PointModelResult",
     "TrackModelResult",
     "GridModelResult",
     "DfsuModelResult",
+    "observation",
     "PointObservation",
     "TrackObservation",
-    "compare",
     "match",
-    "Connector",
     "from_matched",
+    "Comparer",
+    "ComparerCollection",
     "options",
     "get_option",
     "set_option",
@@ -79,7 +80,7 @@ __all__ = [
     "load_style",
     "plotting",
     "from_config",
-    "model_result",
-    "ComparerCollection",
-    "Comparer",
+    "compare",  # deprecated
+    "ModelResult",  # deprecated
+    "Connector",  # deprecated
 ]

--- a/modelskill/observation.py
+++ b/modelskill/observation.py
@@ -29,6 +29,27 @@ def observation(
     gtype: Optional[Literal["point", "track"]] = None,
     **kwargs,
 ):
+    """A factory function for creating an appropriate observation object
+    based on the data and args.
+
+    If 'x' or 'y' is given, a PointObservation is created.
+    If 'x_item' or 'y_item' is given, a TrackObservation is created.
+
+    Parameters
+    ----------
+    data : DataInputType
+        The data to be used for creating the Observation object.
+    gtype : Optional[Literal["point", "track"]]
+        The geometry type of the data. If not specified, it will be guessed from the data.
+    **kwargs
+        Additional keyword arguments to be passed to the Observation constructor.
+
+    Examples
+    --------
+    >>> import modelskill as ms
+    >>> o_pt = ms.observation(df, item=0, x=366844, y=6154291, name="Klagshamn")
+    >>> o_tr = ms.observation("lon_after_lat.dfs0", item="wl", x_item=1, y_item=0)
+    """
     if gtype is None:
         geometry = _guess_gtype(**kwargs)
     else:
@@ -136,10 +157,11 @@ class PointObservation(Observation):
 
     Examples
     --------
-    >>> o1 = PointObservation("klagshamn.dfs0", item=0, x=366844, y=6154291, name="Klagshamn")
-    >>> o1 = PointObservation("klagshamn.dfs0", item="Water Level", x=366844, y=6154291)
-    >>> o1 = PointObservation(df, item=0, x=366844, y=6154291, name="Klagshamn")
-    >>> o1 = PointObservation(df["Water Level"], x=366844, y=6154291)
+    >>> import modelskill as ms
+    >>> o1 = ms.PointObservation("klagshamn.dfs0", item=0, x=366844, y=6154291, name="Klagshamn")
+    >>> o2 = ms.PointObservation("klagshamn.dfs0", item="Water Level", x=366844, y=6154291)
+    >>> o3 = ms.PointObservation(df, item=0, x=366844, y=6154291, name="Klagshamn")
+    >>> o4 = ms.PointObservation(df["Water Level"], x=366844, y=6154291)
     """
 
     def __init__(
@@ -238,13 +260,14 @@ class TrackObservation(Observation):
 
     Examples
     --------
-    >>> o1 = TrackObservation("track.dfs0", item=2, name="c2")
+    >>> import modelskill as ms
+    >>> o1 = ms.TrackObservation("track.dfs0", item=2, name="c2")
 
-    >>> o1 = TrackObservation("track.dfs0", item="wind_speed", name="c2")
+    >>> o1 = ms.TrackObservation("track.dfs0", item="wind_speed", name="c2")
 
-    >>> o1 = TrackObservation("lon_after_lat.dfs0", item="wl", x_item=1, y_item=0)
+    >>> o1 = ms.TrackObservation("lon_after_lat.dfs0", item="wl", x_item=1, y_item=0)
 
-    >>> o1 = TrackObservation("track_wl.dfs0", item="wl", x_item="lon", y_item="lat")
+    >>> o1 = ms.TrackObservation("track_wl.dfs0", item="wl", x_item="lon", y_item="lat")
 
     >>> df = pd.DataFrame(
     ...         {

--- a/tests/observation/test_point_obs.py
+++ b/tests/observation/test_point_obs.py
@@ -118,6 +118,15 @@ def test_from_df(klagshamn_filename, klagshamn_df):
     assert o1.n_points == o3.n_points
 
 
+def test_observation_factory(klagshamn_da):
+    o = ms.observation(klagshamn_da, x=366844, y=6154291, name="Klagshamn")
+    assert isinstance(o, ms.PointObservation)
+
+    with pytest.warns(UserWarning, match="Could not guess geometry"):
+        o = ms.observation(klagshamn_da, name="Klagshamn")
+        assert isinstance(o, ms.PointObservation)
+
+
 def test_hist(klagshamn_filename):
     o1 = ms.PointObservation(
         klagshamn_filename, item=0, x=366844, y=6154291, name="Klagshamn1"

--- a/tests/observation/test_track_obs.py
+++ b/tests/observation/test_track_obs.py
@@ -205,6 +205,15 @@ def test_from_df():
     assert t1.n_points == n
 
 
+def test_observation_factory(obs_tiny_df4):
+    o = ms.observation(obs_tiny_df4, x_item="x", y_item="y", item="alti")
+    assert isinstance(o, ms.TrackObservation)
+
+    with pytest.warns(UserWarning, match="Could not guess geometry"):
+        o = ms.observation(obs_tiny_df4, item="alti", name="Klagshamn")
+        assert not isinstance(o, ms.TrackObservation)  # ! defaults to PointObservation
+
+
 def test_non_unique_index():
     fn = "tests/testdata/altimetry_NorthSea_20171027.csv"
     df = pd.read_csv(fn, index_col=0, parse_dates=True)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -393,9 +393,9 @@ def test_wind_directions():
         obs_item="obs",
         quantity=ms.Quantity("Wind direction", unit="degree", is_directional=True),
     )
-    s = cc.skill()
-    assert s.df.loc["obs", "c_max_error"] == pytest.approx(2.0)
-    assert s.df.loc["obs", "c_rmse"] == pytest.approx(1.322875655532)
+    df = cc.skill().to_dataframe()
+    assert df.loc["obs", "c_max_error"] == pytest.approx(2.0)
+    assert df.loc["obs", "c_rmse"] == pytest.approx(1.322875655532)
 
 
 def test_specifying_mod_item_not_allowed_twice(o1, mr1):


### PR DESCRIPTION
A factory function for creating an appropriate observation object based on the data and args.

If 'x' or 'y' is given, a PointObservation is created.
If 'x_item' or 'y_item' is given, a TrackObservation is created.

    >>> import modelskill as ms
    >>> o_pt = ms.observation(df, item=0, x=366844, y=6154291, name="Klagshamn")
    >>> o_tr = ms.observation("lon_after_lat.dfs0", item="wl", x_item=1, y_item=0)
   
Equivalent to `ms.model_result`