### PR TITLE
PR when no joint peaks

### DIFF
--- a/modelskill/metrics.py
+++ b/modelskill/metrics.py
@@ -560,7 +560,7 @@ def peak_ratio(
             Maximum time interval between peaks (default: 36 hours).
 
     $$
-    \frac{\sum_{i=1}^{N_{joint-peaks}} (\frac{Peak_model_i}{Peak_obs_i} )}{N_{joint-peaks}}
+    \frac{\sum_{i=1}^{N_{joint-peaks}} (\frac{Peak_{model_i}}{Peak_{obs_i}} )}{N_{joint-peaks}}
     $$
 
     Range: $[0, \infty)$; Best: 1.0

--- a/modelskill/metrics.py
+++ b/modelskill/metrics.py
@@ -605,9 +605,7 @@ def peak_ratio(
     mod_joint = found_peaks_mod.loc[indices_mod]
 
     if len(obs_joint) == 0 or len(mod_joint) == 0:
-        raise ValueError(
-            f"Combination of Model/Measurements does not have overlapping peaks within inter_event_time={inter_event_time}"
-        )
+        return np.nan
     res = np.mean(mod_joint.values / obs_joint.values)
     return res
 


### PR DESCRIPTION
Hi,
as discussed, if PR does not find any joint-peaks, instead of raising a value error we will be returning NaN as is done in other metrics.