### PR TITLE
Improved mkdocs.yml settings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: modelskill
-
+site_url: https://dhi.github.io/modelskill/
 theme: 
   name: material
   features:
@@ -8,6 +8,7 @@ theme:
     - navigation.expand
     - navigation.sections
     - navigation.indexes
+  # toc-depth: 1
 
 nav: 
   - 'index.md'
@@ -52,17 +53,20 @@ extra_javascript:
   - javascripts/mathjax.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
-
+repo_name: DHI/modelskill
+repo_url: https://github.com/DHI/modelskill
 plugins:
 - search
 - autorefs
 - mkdocstrings:
     handlers:
       python:
-        options:
-          show_source: True
-          inherited_members: True
-          show_root_heading: True
-          show_symbol_type_heading: True
+        options: 
+          show_source: true
+          separate_signature: true
+          inherited_members: true
+          show_root_heading: true
+          # show_root_toc_entry: false
+          show_symbol_type_heading: true
           heading_level: 2
           docstring_style: "numpy" # default is google


### PR DESCRIPTION
Still cannot manage to remove level 3 headings in right hand side TOC (e.g. "See Also") 🤯

This improvements are included: 

![image](https://github.com/DHI/modelskill/assets/34088801/440e2bd4-96d5-4c9a-a861-9e677d8b3b5d)

![image](https://github.com/DHI/modelskill/assets/34088801/7b9f0187-d069-4e9b-9926-ad62efdf8cb4)

See also 

- https://github.com/tiangolo/fastapi/blob/master/docs/en/mkdocs.yml
- https://mkdocstrings.github.io/python/usage/
- https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/