### PR TITLE
Link to github

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,6 @@
 site_name: modelskill
+repo_url: https://github.com/DHI/modelskill
+repo_name: DHI/modelskill
 
 theme: 
   name: material


### PR DESCRIPTION

Directing users to the website seems like the obvious choice, but it doesn't hurt with a link to the repo as well.
![image](https://github.com/DHI/modelskill/assets/614215/62cbe1f2-2a6f-4246-8960-1d37fcfe9d9f)
