### PR TITLE
Skill table in plotly scatter

### DIFF
--- a/modelskill/comparison/_collection_plotter.py
+++ b/modelskill/comparison/_collection_plotter.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, List, Union, Optional, Tuple, Sequence, TYPE_CHECKING
+from typing import Any, List, Literal, Union, Optional, Tuple, Sequence, TYPE_CHECKING
 from matplotlib.axes import Axes
 import matplotlib.colors as colors
 import warnings
@@ -38,7 +38,7 @@ class ComparerCollectionPlotter:
         show_hist: Optional[bool] = None,
         show_density: Optional[bool] = None,
         norm: Optional[colors.Normalize] = None,
-        backend: str = "matplotlib",
+        backend: Literal["matplotlib", "plotly"] = "matplotlib",
         figsize: Tuple[float, float] = (8, 8),
         xlim: Optional[Tuple[float, float]] = None,
         ylim: Optional[Tuple[float, float]] = None,
@@ -175,7 +175,7 @@ class ComparerCollectionPlotter:
         show_points: bool | int | float | None,
         show_hist: Optional[bool],
         show_density: Optional[bool],
-        backend: str,
+        backend: Literal["matplotlib", "plotly"],
         figsize: Tuple[float, float],
         xlim: Optional[Tuple[float, float]],
         ylim: Optional[Tuple[float, float]],

--- a/modelskill/comparison/_comparer_plotter.py
+++ b/modelskill/comparison/_comparer_plotter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import (
+    Literal,
     Union,
     List,
     Optional,
@@ -456,7 +457,7 @@ class ComparerPlotter:
         show_hist: Optional[bool] = None,
         show_density: Optional[bool] = None,
         norm: Optional[colors.Normalize] = None,
-        backend: str = "matplotlib",
+        backend: Literal["matplotlib", "plotly"] = "matplotlib",
         figsize: Tuple[float, float] = (8, 8),
         xlim: Optional[Tuple[float, float]] = None,
         ylim: Optional[Tuple[float, float]] = None,
@@ -589,7 +590,7 @@ class ComparerPlotter:
         show_hist: Optional[bool],
         show_density: Optional[bool],
         norm: Optional[colors.Normalize],
-        backend: str,
+        backend: Literal["matplotlib", "plotly"],
         figsize: Tuple[float, float],
         xlim: Optional[Tuple[float, float]],
         ylim: Optional[Tuple[float, float]],

--- a/modelskill/plotting/_misc.py
+++ b/modelskill/plotting/_misc.py
@@ -156,6 +156,7 @@ def format_skill_table(skill_scores: Mapping[str, float], unit: str) -> pd.DataF
 
     lines = [_format_skill_line(key, value, unit) for key, value in kv.items()]
 
+    # TODO add sign and unit columns
     df = pd.DataFrame(lines, columns=["name", "sep", "value"])
     return df
 

--- a/modelskill/plotting/_scatter.py
+++ b/modelskill/plotting/_scatter.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Sequence, Tuple, Callable, TYPE_CHECKING, Mapping
+from typing import Literal, Optional, Sequence, Tuple, Callable, TYPE_CHECKING, Mapping
 import warnings
 
 if TYPE_CHECKING:
@@ -33,7 +33,7 @@ def scatter(
     show_hist: Optional[bool] = None,
     show_density: Optional[bool] = None,
     norm: Optional[colors.Normalize] = None,
-    backend: str = "matplotlib",
+    backend: Literal["matplotlib", "plotly"] = "matplotlib",
     figsize: Tuple[float, float] = (8, 8),
     xlim: Optional[Tuple[float, float]] = None,
     ylim: Optional[Tuple[float, float]] = None,

--- a/modelskill/plotting/_scatter.py
+++ b/modelskill/plotting/_scatter.py
@@ -380,8 +380,8 @@ def _scatter_plotly(
     xlim,
     ylim,
     title,
-    skill_scores,  # TODO implement
-    skill_score_unit,  # TODO implement
+    skill_scores,
+    skill_score_unit,
     fit_to_quantiles,
     **kwargs,
 ):

--- a/modelskill/plotting/_scatter.py
+++ b/modelskill/plotting/_scatter.py
@@ -475,8 +475,32 @@ def _scatter_plotly(
     )
 
     fig = go.Figure(data=data, layout=layout)
-    fig.update_xaxes(range=xlim)
-    fig.update_yaxes(range=ylim)
+    fig.update_xaxes(range=xlim, nticks=10)
+    fig.update_yaxes(range=ylim, nticks=10)
+
+    if skill_scores is not None:
+        table = format_skill_table(skill_scores=skill_scores, unit=skill_score_unit)
+        lines = [
+            f"{row['name']:<6} {row['sep']} {row['value']:<6}"
+            for _, row in table.iterrows()
+        ]
+
+        # add text box
+        fig.add_annotation(
+            x=0.99,
+            y=0.01,
+            xref="paper",
+            yref="paper",
+            text="<br>".join(lines),
+            showarrow=False,
+            align="left",
+            bordercolor="black",
+            borderwidth=1,
+            borderpad=4,
+            bgcolor="white",
+            font=dict(family="Consolas, 'Liberation Mono', monospace"),
+        )
+
     fig.show()  # Should this be here
 
 


### PR DESCRIPTION
`skill_table` arg was previously silently ignored if the plotly backend was used in the scatter plot.

This PR introduces the possibility to quickly add a skill table to an interactive scatter plot as well.

![image](https://github.com/DHI/modelskill/assets/614215/1a0f55b5-543d-413d-aaf2-098740859299)
