### PR TITLE
Don't sort on groupby (e.g. in skill() method)

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [ main]
   pull_request:
-    branches: [ main ]
 
 jobs:
   build:

--- a/modelskill/comparison/_collection.py
+++ b/modelskill/comparison/_collection.py
@@ -82,7 +82,10 @@ def _all_df_template(n_quantities: int = 1):
 class ComparerCollection(Mapping, Scoreable):
     """
     Collection of comparers, constructed by calling the `modelskill.match`
-    method. Can be indexed by name or index.
+    method or by initializing with a list of comparers.
+
+    NOTE: In case of multiple model results with different time coverage,
+    only the _overlapping_ time period will be used! (intersection)
 
     Examples
     --------
@@ -90,9 +93,12 @@ class ComparerCollection(Mapping, Scoreable):
     >>> mr = ms.DfsuModelResult("Oresund2D.dfsu", item=0)
     >>> o1 = ms.PointObservation("klagshamn.dfs0", item=0, x=366844, y=6154291, name="Klagshamn")
     >>> o2 = ms.PointObservation("drogden.dfs0", item=0, x=355568.0, y=6156863.0)
-    >>> cc = ms.match(obs=[o1,o2], mod=mr)
-    >>> sk = cc.skill()
-    >>> cc["Klagshamn"].plot.timeseries()
+    >>> cmp1 = ms.match(o1, mr)  # Comparer
+    >>> cmp2 = ms.match(o2, mr)  # Comparer
+    >>> ccA = ms.ComparerCollection([cmp1, cmp2])
+    >>> ccB = ms.match(obs=[o1, o2], mod=mr)
+    >>> sk = ccB.skill()
+    >>> ccB["Klagshamn"].plot.timeseries()
     """
 
     plotter = ComparerCollectionPlotter

--- a/modelskill/comparison/_collection.py
+++ b/modelskill/comparison/_collection.py
@@ -950,7 +950,7 @@ class ComparerCollection(Mapping, Scoreable):
                 weights = np.ones(n_obs)  # equal weight to all
             elif isinstance(weights, dict):
                 w_dict = weights
-                weights = [w_dict.get(name, 1.0) for name in (self.obs_names)]
+                weights = [w_dict.get(name, 1.0) for name in observations]
 
             elif isinstance(weights, str):
                 if weights.lower() == "equal":

--- a/modelskill/comparison/_collection.py
+++ b/modelskill/comparison/_collection.py
@@ -606,6 +606,7 @@ class ComparerCollection(Mapping, Scoreable):
         if observed:
             res = res.loc[~(res == False).any(axis=1)]  # noqa
         res.index.name = "time"
+        # TODO change index to regular column, it is not unique
         return res
 
     @staticmethod

--- a/modelskill/comparison/_collection.py
+++ b/modelskill/comparison/_collection.py
@@ -562,9 +562,11 @@ class ComparerCollection(Mapping, Scoreable):
         res = _groupby_df(df, by, pmetrics)
         mtr_cols = [m.__name__ for m in pmetrics]  # type: ignore
         res = res.dropna(subset=mtr_cols, how="all")  # TODO: ok to remove empty?
-        groupby_xy = df[["x", "y"]].groupby(by=by, observed=False, sort=False)
-        res["x"] = groupby_xy.x.first() if groupby_xy.x.nunique() == 1 else np.nan
-        res["y"] = groupby_xy.y.first() if groupby_xy.y.nunique() == 1 else np.nan
+        groupby_xy = df.groupby(
+            by=by, observed=False, sort=False
+        )  # TODO: second time we do the same groupby!!!
+        res["x"] = groupby_xy.x.first()  # if groupby_xy.x.nunique() == 1 else np.nan
+        res["y"] = groupby_xy.y.first()  # if groupby_xy.y.nunique() == 1 else np.nan
         # TODO: set x,y to NaN if TrackObservation, x.nunique() > 1
         res = cc._add_as_col_if_not_in_index(df, skilldf=res)
         return SkillTable(res)

--- a/modelskill/comparison/_collection.py
+++ b/modelskill/comparison/_collection.py
@@ -587,13 +587,17 @@ class ComparerCollection(Mapping, Scoreable):
             for mod_name in cmp.mod_names:
                 # drop "x", "y",  ?
                 df = (
-                    pd.DataFrame({"mod_val": cmp.data[mod_name].values.copy()})
+                    cmp.data[[mod_name]]
+                    .to_dataframe()
+                    .copy()
+                    .rename(columns={mod_name: "mod_val"})
                     .assign(model=mod_name, observation=cmp.name, x=cmp.x, y=cmp.y)
                     .assign(obs_val=cmp.data["Observation"].values)
                     .assign(**attrs)
                 )
                 if self.n_quantities > 1:
                     df["quantity"] = cmp.quantity.name
+
                 frames.append(df)
         res = pd.concat(frames)
         cat_cols = res.select_dtypes(include=["object"]).columns

--- a/modelskill/comparison/_collection_plotter.py
+++ b/modelskill/comparison/_collection_plotter.py
@@ -497,13 +497,13 @@ class ComparerCollectionPlotter:
 
         metrics = [mtr._std_obs, mtr._std_mod, mtr.cc]
         skill_func = self.cc.mean_skill if aggregate_observations else self.cc.skill
-        s = skill_func(
+        sk = skill_func(
             metrics=metrics,  # type: ignore
         )
-        if s is None:
+        if sk is None:
             return
 
-        df = s.to_dataframe()
+        df = sk.to_dataframe()
         ref_std = 1.0 if normalize_std else df.iloc[0]["_std_obs"]
 
         if isinstance(df.index, pd.MultiIndex):

--- a/modelskill/comparison/_comparison.py
+++ b/modelskill/comparison/_comparison.py
@@ -1107,8 +1107,8 @@ class Comparer(Scoreable):
             n            (x, y) int32 3 0 0 14 37 17 50 36 72 ... 0 0 15 20 0 0 0 28 76
             bias         (x, y) float64 -0.02626 nan nan ... nan 0.06785 -0.1143
 
-        >>> ds = cc.gridded_skill(binsize=0.5)
-        >>> ds.coords
+        >>> gs = cc.gridded_skill(binsize=0.5)
+        >>> gs.data.coords
         Coordinates:
             observation   'alti'
         * x            (x) float64 -1.5 -0.5 0.5 1.5 2.5 3.5 4.5 5.5 6.5 7.5

--- a/modelskill/comparison/_comparison.py
+++ b/modelskill/comparison/_comparison.py
@@ -1184,6 +1184,28 @@ class Comparer(Scoreable):
             )
         return cmp
 
+    def to_dataframe(self) -> pd.DataFrame:
+        """Convert matched data to pandas DataFrame
+
+        Include x, y coordinates only if gtype=track
+
+        Returns
+        -------
+        pd.DataFrame
+            data as a pandas DataFrame
+        """
+        if self.gtype == str(GeometryType.POINT):
+            # we remove the scalar coordinate variables as they
+            # will otherwise be columns in the dataframe
+            return self.data.drop_vars(["x", "y", "z"]).to_dataframe()
+        elif self.gtype == str(GeometryType.TRACK):
+            df = self.data.drop_vars(["z"]).to_dataframe()
+            # make sure that x, y cols are first
+            cols = ["x", "y"] + [c for c in df.columns if c not in ["x", "y"]]
+            return df[cols]
+        else:
+            raise NotImplementedError(f"Unknown gtype: {self.gtype}")
+
     def save(self, filename: Union[str, Path]) -> None:
         """Save to netcdf file
 

--- a/modelskill/comparison/_comparison.py
+++ b/modelskill/comparison/_comparison.py
@@ -973,9 +973,8 @@ class Comparer(Scoreable):
 
         df = cmp._to_long_dataframe()
         res = _groupby_df(df, by, metrics)
-        res["x"] = df.groupby(by=by, observed=False).x.first()
-        res["y"] = df.groupby(by=by, observed=False).y.first()
-        # TODO: set x,y to NaN if TrackObservation
+        res["x"] = np.nan if self.gtype == "track" else cmp.x
+        res["y"] = np.nan if self.gtype == "track" else cmp.y
         res = self._add_as_col_if_not_in_index(df, skilldf=res)
         return SkillTable(res)
 

--- a/modelskill/comparison/_utils.py
+++ b/modelskill/comparison/_utils.py
@@ -51,14 +51,11 @@ def _groupby_df(
 ) -> pd.DataFrame:
     def calc_metrics(group):
         row = {}
-        # row["x"] = group.x.first() if group.x.nunique() == 1 else np.nan
-        # row["y"] = group.y.first() if group.y.nunique() == 1 else np.nan
         row["n"] = len(group)
         for metric in metrics:
             row[metric.__name__] = metric(group.obs_val, group.mod_val)
         return pd.Series(row)
 
-    # .drop(columns=["x", "y"])
     if _dt_in_by(by):
         df, by = _add_dt_to_df(df, by)
 

--- a/modelskill/comparison/_utils.py
+++ b/modelskill/comparison/_utils.py
@@ -63,7 +63,7 @@ def _groupby_df(
         df, by = _add_dt_to_df(df, by)
 
     # sort=False to avoid re-ordering compared to original cc (also for performance)
-    res = df.groupby(by=by, observed=False).apply(calc_metrics)
+    res = df.groupby(by=by, observed=False, sort=False).apply(calc_metrics)
 
     if n_min:
         # nan for all cols but n

--- a/modelskill/matching.py
+++ b/modelskill/matching.py
@@ -185,7 +185,14 @@ def match(
     gtype=None,
     max_model_gap=None,
 ):
-    """Compare observations and model results
+    """Match observation and model result data in space and time
+
+    NOTE: In case of multiple model results with different time coverage,
+    only the _overlapping_ time period will be used! (intersection)
+
+    NOTE: In case of multiple observations, multiple models can _only_
+    be matched if they are _all_ of SpatialField type, e.g. DfsuModelResult
+    or GridModelResult.
 
     Parameters
     ----------

--- a/modelskill/matching.py
+++ b/modelskill/matching.py
@@ -475,9 +475,14 @@ def _select_overlapping_trackdata_with_tolerance(
     df = mod_df.join(obs_df, how="inner", lsuffix="_mod", rsuffix="_obs")
 
     # 2. remove model points outside observation track
+    n_points = len(df)
     keep_x = np.abs((df.x_mod - df.x_obs)) < spatial_tolerance
     keep_y = np.abs((df.y_mod - df.y_obs)) < spatial_tolerance
     df = df[keep_x & keep_y]
+    if n_points_removed := n_points - len(df):
+        warnings.warn(
+            f"Removed {n_points_removed} model points outside observation track (spatial_tolerance={spatial_tolerance})"
+        )
     return mri.data.sel(time=df.index)
 
 

--- a/modelskill/skill.py
+++ b/modelskill/skill.py
@@ -86,10 +86,10 @@ class SkillArrayPlotter:
 
         Examples
         --------
-        >>> s = cc.skill()["rmse"]
-        >>> s.plot.line()
-        >>> s.plot.line(marker="o", linestyle=':')
-        >>> s.plot.line(color=['0.2', '0.4', '0.6'])
+        >>> sk = cc.skill()["rmse"]
+        >>> sk.plot.line()
+        >>> sk.plot.line(marker="o", linestyle=':')
+        >>> sk.plot.line(color=['0.2', '0.4', '0.6'])
         """
         df = self._get_plot_df(level=level)
         self._name_to_title_in_kwargs(kwargs)
@@ -123,11 +123,11 @@ class SkillArrayPlotter:
 
         Examples
         --------
-        >>> s = cc.skill()["rmse"]
-        >>> s.plot.bar()
-        >>> s.plot.bar(level="observation")
-        >>> s.plot.bar(title="Root Mean Squared Error")
-        >>> s.plot.bar(color=["red","blue"])
+        >>> sk = cc.skill()["rmse"]
+        >>> sk.plot.bar()
+        >>> sk.plot.bar(level="observation")
+        >>> sk.plot.bar(title="Root Mean Squared Error")
+        >>> sk.plot.bar(color=["red","blue"])
         """
         df = self._get_plot_df(level=level)
         self._name_to_title_in_kwargs(kwargs)
@@ -150,10 +150,10 @@ class SkillArrayPlotter:
 
         Examples
         --------
-        >>> s = cc.skill()["rmse"]
-        >>> s.plot.barh()
-        >>> s.plot.barh(level="observation")
-        >>> s.plot.barh(title="Root Mean Squared Error")
+        >>> sk = cc.skill()["rmse"]
+        >>> sk.plot.barh()
+        >>> sk.plot.barh(level="observation")
+        >>> sk.plot.barh(title="Root Mean Squared Error")
         """
         df = self._get_plot_df(level)
         self._name_to_title_in_kwargs(kwargs)
@@ -197,11 +197,11 @@ class SkillArrayPlotter:
 
         Examples
         --------
-        >>> s = cc.skill()["rmse"]
-        >>> s.plot.grid()
-        >>> s.plot.grid(show_numbers=False, cmap="magma")
-        >>> s.plot.grid(precision=1)
-        >>> s.plot.grid(fmt=".0%", title="Root Mean Squared Error")
+        >>> sk = cc.skill()["rmse"]
+        >>> sk.plot.grid()
+        >>> sk.plot.grid(show_numbers=False, cmap="magma")
+        >>> sk.plot.grid(precision=1)
+        >>> sk.plot.grid(fmt=".0%", title="Root Mean Squared Error")
         """
 
         s = self.skillarray
@@ -300,9 +300,9 @@ class SkillArray:
 
     Examples
     --------
-    >>> s = cc.skill()   # SkillTable
-    >>> s.rmse           # SkillArray
-    >>> s.rmse.plot.line()
+    >>> sk = cc.skill()   # SkillTable
+    >>> sk.rmse           # SkillArray
+    >>> sk.rmse.plot.line()
     """
 
     def __init__(self, data: pd.DataFrame) -> None:
@@ -355,12 +355,12 @@ class SkillTable:
 
     Examples
     --------
-    >>> s = cc.skill()
-    >>> s.mod_names
+    >>> sk = cc.skill()
+    >>> sk.mod_names
     ['SW_1', 'SW_2']
-    >>> s.style()
-    >>> s.sel(model='SW_1').style()
-    >>> s.rmse.plot.bar()
+    >>> sk.style()
+    >>> sk.sel(model='SW_1').style()
+    >>> sk.rmse.plot.bar()
     """
 
     _large_is_best_metrics = [
@@ -525,8 +525,8 @@ class SkillTable:
 
         Examples
         --------
-        >>> s = cc.skill()
-        >>> s_above_0p3 = s.query("rmse>0.3")
+        >>> sk = cc.skill()
+        >>> sk_above_0p3 = sk.query("rmse>0.3")
         """
         return self.__class__(self._df.query(query))
 
@@ -552,9 +552,9 @@ class SkillTable:
 
         Examples
         --------
-        >>> s = cc.skill()
-        >>> s_SW1 = s.sel(model = "SW_1")
-        >>> s2 = s.sel(observation = ["EPL", "HKNA"])
+        >>> sk = cc.skill()
+        >>> sk_SW1 = sk.sel(model = "SW_1")
+        >>> sk2 = sk.sel(observation = ["EPL", "HKNA"])
         """
         if query is not None:
             warnings.warn(
@@ -667,10 +667,10 @@ class SkillTable:
 
         Examples
         --------
-        >>> s = cc.skill()
-        >>> s.style()
-        >>> s.style(precision=1, metrics="rmse")
-        >>> s.style(cmap="Blues", show_best=False)
+        >>> sk = cc.skill()
+        >>> sk.style()
+        >>> sk.style(precision=1, metrics="rmse")
+        >>> sk.style(cmap="Blues", show_best=False)
         """
         # identity metric columns
         float_cols = list(self._df.select_dtypes(include="number").columns)

--- a/modelskill/skill.py
+++ b/modelskill/skill.py
@@ -527,7 +527,7 @@ class SkillTable:
 
     @property
     def loc(self, *args, **kwargs):
-        return self._df.loc(*args, **kwargs)
+        return self.data.loc(*args, **kwargs)
 
     def sort_index(self, *args, **kwargs) -> SkillTable:
         """Sort by index (level) e.g. sorting by observation
@@ -545,7 +545,7 @@ class SkillTable:
         >>> sk.sort_index()
         >>> sk.sort_index(level="observation")
         """
-        return self.__class__(self._df.sort_index(*args, **kwargs))
+        return self.__class__(self.data.sort_index(*args, **kwargs))
 
     def sort_values(self, *args, **kwargs) -> SkillTable:
         """Sort by values e.g. sorting by rmse values
@@ -562,8 +562,9 @@ class SkillTable:
         >>> sk = cc.skill()
         >>> sk.sort_values("rmse")
         >>> sk.sort_values("rmse", ascending=False)
+        >>> sk.sort_values(["n", "rmse"])
         """
-        return self.__class__(self._df.sort_values(*args, **kwargs))
+        return self.__class__(self.data.sort_values(*args, **kwargs))
 
     def swaplevel(self, *args, **kwargs) -> SkillTable:
         """Swap the levels of the MultiIndex e.g. swapping 'model' and 'observation'
@@ -582,7 +583,7 @@ class SkillTable:
         >>> sk.swaplevel("model", "observation")
         >>> sk.swaplevel(0, 1)
         """
-        return self.__class__(self._df.swaplevel(*args, **kwargs))
+        return self.__class__(self.data.swaplevel(*args, **kwargs))
 
     @property
     def mod_names(self) -> list[str]:
@@ -629,7 +630,7 @@ class SkillTable:
         >>> sk = cc.skill()
         >>> sk_above_0p3 = sk.query("rmse>0.3")
         """
-        return self.__class__(self._df.query(query))
+        return self.__class__(self.data.query(query))
 
     def sel(self, query=None, reduce_index=True, **kwargs):
         """Select a subset of the SkillTable by a query,

--- a/modelskill/skill.py
+++ b/modelskill/skill.py
@@ -529,16 +529,59 @@ class SkillTable:
     def loc(self, *args, **kwargs):
         return self._df.loc(*args, **kwargs)
 
-    def sort_index(self, *args, **kwargs):
-        """Wrapping pd.DataFrame.sort_index() for e.g. sorting by observation"""
+    def sort_index(self, *args, **kwargs) -> SkillTable:
+        """Sort by index (level) e.g. sorting by observation
+
+        Wrapping pd.DataFrame.sort_index()
+
+        Returns
+        -------
+        SkillTable
+            A new SkillTable with sorted index
+
+        Examples
+        --------
+        >>> sk = cc.skill()
+        >>> sk.sort_index()
+        >>> sk.sort_index(level="observation")
+        """
         return self.__class__(self._df.sort_index(*args, **kwargs))
 
-    def sort_values(self, *args, **kwargs):
-        """Wrapping pd.DataFrame.sort_values() for e.g. sorting by rmse values"""
+    def sort_values(self, *args, **kwargs) -> SkillTable:
+        """Sort by values e.g. sorting by rmse values
+
+        Wrapping pd.DataFrame.sort_values()
+
+        Returns
+        -------
+        SkillTable
+            A new SkillTable with sorted values
+
+        Examples
+        --------
+        >>> sk = cc.skill()
+        >>> sk.sort_values("rmse")
+        >>> sk.sort_values("rmse", ascending=False)
+        """
         return self.__class__(self._df.sort_values(*args, **kwargs))
 
-    def swaplevel(self, *args, **kwargs):
-        """Wrapping pd.DataFrame.swaplevel() for e.g. swapping model and observation"""
+    def swaplevel(self, *args, **kwargs) -> SkillTable:
+        """Swap the levels of the MultiIndex e.g. swapping 'model' and 'observation'
+
+        Wrapping pd.DataFrame.swaplevel()
+
+        Returns
+        -------
+        SkillTable
+            A new SkillTable with swapped levels
+
+        Examples
+        --------
+        >>> sk = cc.skill()
+        >>> sk.swaplevel().sort_index(level="observation")
+        >>> sk.swaplevel("model", "observation")
+        >>> sk.swaplevel(0, 1)
+        """
         return self.__class__(self._df.swaplevel(*args, **kwargs))
 
     @property

--- a/modelskill/skill.py
+++ b/modelskill/skill.py
@@ -311,7 +311,18 @@ class SkillArray:
         self.plot = SkillArrayPlotter(self)
 
     def to_dataframe(self, drop_xy=True) -> pd.DataFrame:
-        """Output as pd.DataFrame"""
+        """Convert SkillArray to pd.DataFrame
+
+        Parameters
+        ----------
+        drop_xy : bool, optional
+            Drop the x, y coordinates?, by default True
+
+        Returns
+        -------
+        pd.DataFrame
+            Skill data as pd.DataFrame
+        """
         if drop_xy:
             return self._ser.to_frame()
         else:
@@ -329,6 +340,23 @@ class SkillArray:
         return self._ser.name
 
     def to_geodataframe(self, crs="EPSG:4326") -> gpd.GeoDataFrame:
+        """Convert SkillArray to geopandas.GeoDataFrame
+
+        Note: requires geopandas to be installed
+
+        Note: requires x and y columns to be present
+
+        Parameters
+        ----------
+        crs : str, optional
+            Coordinate reference system identifier passed to the
+            GeoDataFrame constructor, by default "EPSG:4326"
+
+        Returns
+        -------
+        gpd.GeoDataFrame
+            Skill data as GeoDataFrame
+        """
         import geopandas as gpd
 
         assert "x" in self.data.columns
@@ -395,10 +423,10 @@ class SkillTable:
         self.plot = DeprecatedSkillPlotter(self)  # TODO remove in v1.1
 
     # TODO: remove?
-    # data without xy columns
     @property
     def _df(self) -> pd.DataFrame:
-        return self.data.drop(columns=["x", "y"], errors="ignore")
+        """Data as DataFrame without x and y columns"""
+        return self.to_dataframe(drop_xy=True)
 
     @property
     def metrics(self) -> Collection[str]:
@@ -410,12 +438,41 @@ class SkillTable:
         return len(self._df)
 
     def to_dataframe(self, drop_xy=True) -> pd.DataFrame:
+        """Convert SkillTable to pd.DataFrame
+
+        Parameters
+        ----------
+        drop_xy : bool, optional
+            Drop the x, y coordinates?, by default True
+
+        Returns
+        -------
+        pd.DataFrame
+            Skill data as pd.DataFrame
+        """
         if drop_xy:
             return self.data.drop(columns=["x", "y"], errors="ignore")
         else:
             return self.data.copy()
 
     def to_geodataframe(self, crs="EPSG:4326") -> gpd.GeoDataFrame:
+        """Convert SkillTable to geopandas.GeoDataFrame
+
+        Note: requires geopandas to be installed
+
+        Note: requires x and y columns to be present
+
+        Parameters
+        ----------
+        crs : str, optional
+            Coordinate reference system identifier passed to the
+            GeoDataFrame constructor, by default "EPSG:4326"
+
+        Returns
+        -------
+        gpd.GeoDataFrame
+            Skill data as GeoDataFrame
+        """
         import geopandas as gpd
 
         assert "x" in self.data.columns
@@ -468,17 +525,18 @@ class SkillTable:
         # For other attributes, return them directly
         return getattr(self.data, item)
 
-    # TODO
     @property
     def loc(self, *args, **kwargs):
         return self._df.loc(*args, **kwargs)
 
-    # TODO: remove?
     def sort_index(self, *args, **kwargs):
         """Wrapping pd.DataFrame.sort_index() for e.g. sorting by observation"""
         return self.__class__(self._df.sort_index(*args, **kwargs))
 
-    # TODO: remove?
+    def sort_values(self, *args, **kwargs):
+        """Wrapping pd.DataFrame.sort_values() for e.g. sorting by rmse values"""
+        return self.__class__(self._df.sort_values(*args, **kwargs))
+
     def swaplevel(self, *args, **kwargs):
         """Wrapping pd.DataFrame.swaplevel() for e.g. swapping model and observation"""
         return self.__class__(self._df.swaplevel(*args, **kwargs))
@@ -498,8 +556,8 @@ class SkillTable:
         """List of quantity names (in index)"""
         return self._get_index_level_by_name("quantity")
 
-    # TODO what does this method actually do?
     def _get_index_level_by_name(self, name):
+        # Helper function to get unique values of a level in the index (e.g. model)
         index = self._df.index
         if name in index.names:
             level = index.names.index(name)
@@ -571,7 +629,6 @@ class SkillTable:
                 )
                 return self[value]
 
-        # df = self._df
         df = self.to_dataframe(drop_xy=False)
 
         for key, value in kwargs.items():
@@ -633,6 +690,11 @@ class SkillTable:
             Number of decimal places to round to (default: 3).
             If decimals is negative, it specifies the number of
             positions to the left of the decimal point.
+
+        Returns
+        -------
+        SkillTable
+            A new SkillTable with rounded values
         """
 
         return self.__class__(self.data.round(decimals=decimals))
@@ -774,6 +836,8 @@ class SkillTable:
             "text-decoration: underline; font-style: italic; font-weight: bold;"
         )
         return [cell_style if v else "" for v in (s == s.max())]
+
+    # =============== Deprecated methods ===============
 
     # TODO: remove plot_* methods in v1.1; warnings are not needed
     # as the refering method is also deprecated

--- a/modelskill/skill_grid.py
+++ b/modelskill/skill_grid.py
@@ -48,8 +48,8 @@ class SkillGridArray(SkillGridMixin):
 
     Examples
     --------
-    >>> ss = cc.gridded_skill()
-    >>> ss["bias"].plot()
+    >>> gs = cc.gridded_skill()
+    >>> gs["bias"].plot()
     """
 
     def __init__(self, data):
@@ -75,10 +75,10 @@ class SkillGridArray(SkillGridMixin):
 
         Examples
         --------
-        >>> ss = cc.gridded_skill()
-        >>> ss["bias"].plot()
-        >>> ss.rmse.plot(model='SW_1')
-        >>> ss.r2.plot(cmap='YlOrRd', figsize=(10,10))
+        >>> gs = cc.gridded_skill()
+        >>> gs["bias"].plot()
+        >>> gs.rmse.plot(model='SW_1')
+        >>> gs.r2.plot(cmap='YlOrRd', figsize=(10,10))
         """
         if model is None:
             da = self.data
@@ -113,14 +113,14 @@ class SkillGrid(SkillGridMixin):
 
     Examples
     --------
-    >>> ss = cc.gridded_skill()
-    >>> ss.metrics
+    >>> gs = cc.gridded_skill()
+    >>> gs.metrics
     ['n', 'bias', 'rmse', 'urmse', 'mae', 'cc', 'si', 'r2']
 
-    >>> ss.mod_names
+    >>> gs.mod_names
     ['SW_1', 'SW_2']
 
-    >>> ss.rmse.plot(model='SW_1')
+    >>> gs.sel(model='SW_1').rmse.plot()
     """
 
     def __init__(self, data, name: Optional[str] = None):

--- a/modelskill/skill_grid.py
+++ b/modelskill/skill_grid.py
@@ -209,5 +209,11 @@ class SkillGrid(SkillGridMixin):
         return self[metric].plot(model=model, **kwargs)
 
     def to_dataframe(self):
-        """export as pandas.DataFrame"""
+        """Convert gridded skill data to pandas DataFrame
+
+        Returns
+        -------
+        pd.DataFrame
+            data as a pandas DataFrame
+        """
         return self.data.to_dataframe()

--- a/modelskill/timeseries/_timeseries.py
+++ b/modelskill/timeseries/_timeseries.py
@@ -178,7 +178,7 @@ class TimeSeries:
 
     # TODO: """Color of time series"""; Hide until used
     @property
-    def _color(self) -> str:        
+    def _color(self) -> str:
         return str(self.data[self.name].attrs["color"])
 
     @_color.setter
@@ -258,13 +258,26 @@ class TimeSeries:
         return self.equals(other)
 
     def to_dataframe(self) -> pd.DataFrame:
-        """Convert to pandas DataFrame"""
+        """Convert matched data to pandas DataFrame
+
+        Include x, y coordinates only if gtype=track
+
+        Returns
+        -------
+        pd.DataFrame
+            data as a pandas DataFrame
+        """
         if self.gtype == str(GeometryType.POINT):
             # we remove the scalar coordinate variables as they
             # will otherwise be columns in the dataframe
-            return self.data.drop_vars(["x", "y", "z"])[self.name].to_dataframe()
+            return self.data.drop_vars(["x", "y", "z"]).to_dataframe()
+        elif self.gtype == str(GeometryType.TRACK):
+            df = self.data.drop_vars(["z"]).to_dataframe()
+            # make sure that x, y cols are first
+            cols = ["x", "y"] + [c for c in df.columns if c not in ["x", "y"]]
+            return df[cols]
         else:
-            return self.data.drop_vars(["z"])[["x", "y", self.name]].to_dataframe()
+            raise NotImplementedError(f"Unknown gtype: {self.gtype}")
 
     def sel(self: T, **kwargs: Any) -> T:
         """Select data by label"""

--- a/notebooks/Event-based_timeseries.ipynb
+++ b/notebooks/Event-based_timeseries.ipynb
@@ -20430,8 +20430,8 @@
     }
    ],
    "source": [
-    "ss = cmp.skill(by=\"event\", metrics='rmse')\n",
-    "ss.style()"
+    "sk = cmp.skill(by=\"event\", metrics='rmse')\n",
+    "sk.style()"
    ]
   }
  ],

--- a/notebooks/Metocean_gridded_spatial_skill.ipynb
+++ b/notebooks/Metocean_gridded_spatial_skill.ipynb
@@ -49,7 +49,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "ss = cc.gridded_skill()"
+                "gs = cc.gridded_skill()"
             ]
         },
         {
@@ -502,7 +502,7 @@
                 }
             ],
             "source": [
-                "ss"
+                "gs"
             ]
         },
         {
@@ -522,7 +522,7 @@
                 }
             ],
             "source": [
-                "ss.metrics"
+                "gs.metrics"
             ]
         },
         {
@@ -542,7 +542,7 @@
                 }
             ],
             "source": [
-                "ss.rmse.plot();"
+                "gs.rmse.plot();"
             ]
         },
         {
@@ -562,7 +562,7 @@
                 }
             ],
             "source": [
-                "ss['n'].plot(figsize=(3,3));"
+                "gs['n'].plot(figsize=(3,3));"
             ]
         },
         {
@@ -612,7 +612,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "ss = cc.gridded_skill(by='model', bins=6)"
+                "gs = cc.gridded_skill(by='model', bins=6)"
             ]
         },
         {
@@ -632,7 +632,7 @@
                 }
             ],
             "source": [
-                "ss.mod_names"
+                "gs.mod_names"
             ]
         },
         {
@@ -652,7 +652,7 @@
                 }
             ],
             "source": [
-                "ss.bias.plot();"
+                "gs.bias.plot();"
             ]
         },
         {
@@ -672,7 +672,7 @@
                 }
             ],
             "source": [
-                "ss.rmse.plot(model='SW_1', cmap='YlOrRd');"
+                "gs.rmse.plot(model='SW_1', cmap='YlOrRd');"
             ]
         },
         {

--- a/notebooks/Metocean_multi_model_comparison.ipynb
+++ b/notebooks/Metocean_multi_model_comparison.ipynb
@@ -2245,7 +2245,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "s = cc.skill()"
+                "sk = cc.skill()"
             ]
         },
         {
@@ -2493,7 +2493,7 @@
                 }
             ],
             "source": [
-                "s.style()"
+                "sk.style()"
             ]
         },
         {
@@ -2741,7 +2741,7 @@
                 }
             ],
             "source": [
-                "s.style(columns='rmse')"
+                "sk.style(columns='rmse')"
             ]
         },
         {
@@ -2761,7 +2761,7 @@
                 }
             ],
             "source": [
-                "s[\"rmse\"].plot.bar();"
+                "sk[\"rmse\"].plot.bar();"
             ]
         },
         {
@@ -2770,7 +2770,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "s = cc.skill(by=['model','freq:12H'], metrics=['bias','rmse','si'])"
+                "sk = cc.skill(by=['model','freq:12H'], metrics=['bias','rmse','si'])"
             ]
         },
         {
@@ -3044,7 +3044,7 @@
                 }
             ],
             "source": [
-                "s.style()"
+                "sk.style()"
             ]
         },
         {
@@ -3064,7 +3064,7 @@
                 }
             ],
             "source": [
-                "s[\"rmse\"].plot.line(title='Hm0 rmse [m]');"
+                "sk[\"rmse\"].plot.line(title='Hm0 rmse [m]');"
             ]
         },
         {
@@ -3084,7 +3084,7 @@
                 }
             ],
             "source": [
-                "s[\"si\"].plot.grid(fmt='0.1%', title='Hm0 Scatter index');"
+                "sk[\"si\"].plot.grid(fmt='0.1%', title='Hm0 Scatter index');"
             ]
         },
         {
@@ -3342,8 +3342,8 @@
                 }
             ],
             "source": [
-                "s = cc.skill()\n",
-                "s.style()"
+                "sk = cc.skill()\n",
+                "sk.style()"
             ]
         },
         {
@@ -3479,7 +3479,7 @@
                 }
             ],
             "source": [
-                "s.sel(model='SW_1').style()"
+                "sk.sel(model='SW_1').style()"
             ]
         },
         {
@@ -3579,7 +3579,7 @@
                 }
             ],
             "source": [
-                "s.sel(observation='HKNA').style()"
+                "sk.sel(observation='HKNA').style()"
             ]
         },
         {
@@ -3749,7 +3749,7 @@
                 }
             ],
             "source": [
-                "s.sel('rmse>0.25').style()"
+                "sk.sel('rmse>0.25').style()"
             ]
         },
         {
@@ -3827,7 +3827,7 @@
                 }
             ],
             "source": [
-                "s.sel('rmse>0.3', columns=['rmse','mae']).style()"
+                "sk.sel('rmse>0.3', columns=['rmse','mae']).style()"
             ]
         }
     ],

--- a/notebooks/Metocean_track_comparison.ipynb
+++ b/notebooks/Metocean_track_comparison.ipynb
@@ -1906,7 +1906,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "ss = cmp.gridded_skill(metrics=['bias'])"
+                "gs = cmp.gridded_skill(metrics=['bias'])"
             ]
         },
         {
@@ -2322,7 +2322,7 @@
                 }
             ],
             "source": [
-                "ss['n'].data"
+                "gs['n'].data"
             ]
         },
         {
@@ -2351,8 +2351,8 @@
             ],
             "source": [
                 "fig, axes = plt.subplots(ncols=2, nrows=1, figsize = (10, 5))\n",
-                "ss.n.plot(ax=axes[0])\n",
-                "ss.bias.plot(ax=axes[1]);"
+                "gs.n.plot(ax=axes[0])\n",
+                "gs.bias.plot(ax=axes[1]);"
             ]
         },
         {
@@ -2380,10 +2380,10 @@
                 }
             ],
             "source": [
-                "ss = cmp.gridded_skill(metrics=['bias'], n_min=25)\n",
+                "gs = cmp.gridded_skill(metrics=['bias'], n_min=25)\n",
                 "fig, axes = plt.subplots(ncols=2, nrows=1, figsize=(10, 5))\n",
-                "ss.n.plot(ax=axes[0])\n",
-                "ss.bias.plot(ax=axes[1]);"
+                "gs.n.plot(ax=axes[0])\n",
+                "gs.bias.plot(ax=axes[1]);"
             ]
         },
         {
@@ -3511,8 +3511,8 @@
                 }
             ],
             "source": [
-                "ss = cmp.gridded_skill(by=['wl category'], metrics=['bias'], n_min=5)\n",
-                "ss"
+                "gs = cmp.gridded_skill(by=['wl category'], metrics=['bias'], n_min=5)\n",
+                "gs"
             ]
         },
         {
@@ -3532,7 +3532,7 @@
                 }
             ],
             "source": [
-                "ss.bias.plot();"
+                "gs.bias.plot();"
             ]
         },
         {
@@ -3596,9 +3596,9 @@
             ],
             "source": [
                 "cmp = cmp + cmp2\n",
-                "ss = cmp.gridded_skill(metrics=['bias'], n_min=20)\n",
-                "ss.bias.data.attrs = dict(long_name=\"Bias of surface elevation\", units=\"m\")\n",
-                "ss.bias.plot(figsize=(10,5));"
+                "gs = cmp.gridded_skill(metrics=['bias'], n_min=20)\n",
+                "gs.bias.data.attrs = dict(long_name=\"Bias of surface elevation\", units=\"m\")\n",
+                "gs.bias.plot(figsize=(10,5));"
             ]
         },
         {

--- a/notebooks/Metocean_track_comparison_global.ipynb
+++ b/notebooks/Metocean_track_comparison_global.ipynb
@@ -255,7 +255,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "ss = cmp.gridded_skill(metrics=['bias'], bins=(np.arange(-180,180,1), np.arange(-90,90,1)), n_min=20)"
+                "gs = cmp.gridded_skill(metrics=['bias'], bins=(np.arange(-180,180,1), np.arange(-90,90,1)), n_min=20)"
             ]
         },
         {
@@ -283,7 +283,7 @@
                 }
             ],
             "source": [
-                "type(ss)"
+                "type(gs)"
             ]
         },
         {
@@ -303,11 +303,11 @@
                 }
             ],
             "source": [
-                "ss.bias.data.attrs = dict(long_name=\"Bias of significant wave height, Hm0\",units=\"m\")\n",
-                "ss.n.data.attrs = dict(long_name=\"N of significant wave height\",units=\"-\")\n",
+                "gs.bias.data.attrs = dict(long_name=\"Bias of significant wave height, Hm0\",units=\"m\")\n",
+                "gs.n.data.attrs = dict(long_name=\"N of significant wave height\",units=\"-\")\n",
                 "fig, axes = plt.subplots(ncols=1, nrows=2, figsize = (8, 10))\n",
-                "ss.n.plot(ax=axes[0])\n",
-                "ss.bias.plot(ax=axes[1]);"
+                "gs.n.plot(ax=axes[0])\n",
+                "gs.bias.plot(ax=axes[1]);"
             ]
         },
         {
@@ -893,7 +893,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "ss = cmp.gridded_skill(by=[\"val_cat\"], metrics=[\"bias\"], bins=(np.arange(-180,180,5), np.arange(-90,90,5)), n_min=20)"
+                "gs = cmp.gridded_skill(by=[\"val_cat\"], metrics=[\"bias\"], bins=(np.arange(-180,180,5), np.arange(-90,90,5)), n_min=20)"
             ]
         },
         {
@@ -902,9 +902,9 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "ss.data['bias'].attrs = dict(long_name=\"Bias of significant wave height, Hm0\", units=\"m\")\n",
-                "ss.data['n'].attrs = dict(long_name=\"N of significant wave height\", units=\"-\")\n",
-                "ss.data['val_cat'].attrs = dict(long_name=\"Range of sign. wave height, Hm0\", units=\"m\")"
+                "gs.data['bias'].attrs = dict(long_name=\"Bias of significant wave height, Hm0\", units=\"m\")\n",
+                "gs.data['n'].attrs = dict(long_name=\"N of significant wave height\", units=\"-\")\n",
+                "gs.data['val_cat'].attrs = dict(long_name=\"Range of sign. wave height, Hm0\", units=\"m\")"
             ]
         },
         {
@@ -924,7 +924,7 @@
                 }
             ],
             "source": [
-                "ss.n.plot(figsize=(12,4));"
+                "gs.n.plot(figsize=(12,4));"
             ]
         },
         {
@@ -944,7 +944,7 @@
                 }
             ],
             "source": [
-                "ss.bias.plot(figsize=(12,4));"
+                "gs.bias.plot(figsize=(12,4));"
             ]
         },
         {

--- a/notebooks/Multi_variable_comparison.ipynb
+++ b/notebooks/Multi_variable_comparison.ipynb
@@ -434,8 +434,8 @@
                 }
             ],
             "source": [
-                "s = cc.skill()\n",
-                "s.round(3)"
+                "sk = cc.skill()\n",
+                "sk.round(3)"
             ]
         },
         {
@@ -683,8 +683,8 @@
                 }
             ],
             "source": [
-                "s = cc.sel(quantity='Significant wave height').skill()\n",
-                "s.style()"
+                "sk = cc.sel(quantity='Significant wave height').skill()\n",
+                "sk.style()"
             ]
         },
         {
@@ -784,7 +784,7 @@
                 }
             ],
             "source": [
-                "s.sel(observation='c2_Hm0').style(columns='rmse')"
+                "sk.sel(observation='c2_Hm0').style(columns='rmse')"
             ]
         },
         {
@@ -804,7 +804,7 @@
                 }
             ],
             "source": [
-                "s['rmse'].plot.line(ylabel='Hm0 RMSE [m]');"
+                "sk['rmse'].plot.line(ylabel='Hm0 RMSE [m]');"
             ]
         },
         {
@@ -958,8 +958,8 @@
                 }
             ],
             "source": [
-                "s = cc.mean_skill()\n",
-                "s"
+                "sk = cc.mean_skill()\n",
+                "sk"
             ]
         },
         {
@@ -979,7 +979,7 @@
                 }
             ],
             "source": [
-                "s['si'].plot.bar(title='scatter index');"
+                "sk['si'].plot.bar(title='scatter index');"
             ]
         },
         {

--- a/notebooks/Prematched_with_auxiliary.ipynb
+++ b/notebooks/Prematched_with_auxiliary.ipynb
@@ -1152,8 +1152,8 @@
     }
    ],
    "source": [
-    "ss = cmp.skill(by=\"windsector\")\n",
-    "ss.style()"
+    "sk = cmp.skill(by=\"windsector\")\n",
+    "sk.style()"
    ]
   },
   {
@@ -1173,7 +1173,7 @@
     }
    ],
    "source": [
-    "ss[\"rmse\"].plot.bar(title=\"Hm0 RMSE by wind sector\");"
+    "sk[\"rmse\"].plot.bar(title=\"Hm0 RMSE by wind sector\");"
    ]
   },
   {

--- a/tests/model/test_point.py
+++ b/tests/model/test_point.py
@@ -183,13 +183,13 @@ def test_wave_directional_data_is_directional_by_default():
 
 
 def test_point_aux_items(df_aux):
-    o = ms.PointModelResult(df_aux, item="WL", aux_items=["aux1"])
-    assert "aux1" in o.data
-    assert o.data["aux1"].values[0] == 1.1
+    mr = ms.PointModelResult(df_aux, item="WL", aux_items=["aux1"])
+    assert "aux1" in mr.data
+    assert mr.data["aux1"].values[0] == 1.1
 
-    o = ms.PointModelResult(df_aux, item="WL", aux_items="aux1")
-    assert "aux1" in o.data
-    assert o.data["aux1"].values[0] == 1.1
+    mr = ms.PointModelResult(df_aux, item="WL", aux_items="aux1")
+    assert "aux1" in mr.data
+    assert mr.data["aux1"].values[0] == 1.1
 
 
 def test_point_aux_items_fail(df_aux):
@@ -201,11 +201,11 @@ def test_point_aux_items_fail(df_aux):
 
 
 def test_point_aux_items_multiple(df_aux):
-    o = ms.PointModelResult(df_aux, item="WL", aux_items=["aux1", "aux2"])
-    assert "aux1" in o.data
-    assert "aux2" in o.data
-    assert o.data["aux1"].values[0] == 1.1
-    assert o.data["aux2"].values[0] == 1.2
+    mr = ms.PointModelResult(df_aux, item="WL", aux_items=["aux1", "aux2"])
+    assert "aux1" in mr.data
+    assert "aux2" in mr.data
+    assert mr.data["aux1"].values[0] == 1.1
+    assert mr.data["aux2"].values[0] == 1.2
 
 
 def test_point_modelresult_must_have_unique_and_monotonically_increasing_time():
@@ -226,3 +226,13 @@ def test_point_modelresult_must_have_unique_and_monotonically_increasing_time():
 
     with pytest.raises(ValueError):
         ms.PointModelResult(df_up_and_down, item=0)
+
+
+def test_point_to_dataframe(df_aux):
+    mr = ms.PointModelResult(df_aux, item="WL", aux_items=["aux1", "aux2"])
+    df = mr.to_dataframe()
+    assert isinstance(df, pd.DataFrame)
+    # NOTE: aux items are not included in the dataframe
+    assert df.shape == (6, 1)
+    assert list(df.columns) == ["WL"]
+    assert df.index[0] == datetime(2019, 1, 1, 0, 0, 0)

--- a/tests/model/test_point.py
+++ b/tests/model/test_point.py
@@ -232,7 +232,7 @@ def test_point_to_dataframe(df_aux):
     mr = ms.PointModelResult(df_aux, item="WL", aux_items=["aux1", "aux2"])
     df = mr.to_dataframe()
     assert isinstance(df, pd.DataFrame)
-    # NOTE: aux items are not included in the dataframe
-    assert df.shape == (6, 1)
-    assert list(df.columns) == ["WL"]
+    # NOTE: aux items are included in the dataframe
+    assert df.shape == (6, 3)
+    assert list(df.columns) == ["WL", "aux1", "aux2"]
     assert df.index[0] == datetime(2019, 1, 1, 0, 0, 0)

--- a/tests/model/test_track.py
+++ b/tests/model/test_track.py
@@ -151,6 +151,6 @@ def test_track_to_dataframe(df_aux):
     )
     df = mr.to_dataframe()
     assert isinstance(df, pd.DataFrame)
-    # NOTE: aux items are not included in the dataframe
-    assert df.shape == (6, 3)
-    assert list(df.columns) == ["x", "y", "WL"]
+    # NOTE: aux items are included in the dataframe
+    assert df.shape == (6, 4)
+    assert list(df.columns) == ["x", "y", "WL", "aux1"]

--- a/tests/model/test_track.py
+++ b/tests/model/test_track.py
@@ -112,25 +112,27 @@ def test_track_df_default_items(track_df):
 
 
 def test_track_aux_items(df_aux):
-    o = ms.TrackModelResult(
+    mr = ms.TrackModelResult(
         df_aux, item="WL", x_item="x", y_item="y", aux_items=["aux1"]
     )
-    assert "aux1" in o.data
-    assert o.data["aux1"].values[0] == 1.1
+    assert "aux1" in mr.data
+    assert mr.data["aux1"].values[0] == 1.1
 
-    o = ms.TrackModelResult(df_aux, item="WL", x_item="x", y_item="y", aux_items="aux1")
-    assert "aux1" in o.data
-    assert o.data["aux1"].values[0] == 1.1
+    mr = ms.TrackModelResult(
+        df_aux, item="WL", x_item="x", y_item="y", aux_items="aux1"
+    )
+    assert "aux1" in mr.data
+    assert mr.data["aux1"].values[0] == 1.1
 
 
 def test_track_aux_items_multiple(df_aux):
-    o = ms.TrackModelResult(
+    mr = ms.TrackModelResult(
         df_aux, item="WL", x_item="x", y_item="y", aux_items=["aux2", "aux1"]
     )
-    assert "aux1" in o.data
-    assert o.data["aux1"].values[0] == 1.1
-    assert "aux2" in o.data
-    assert o.data["aux2"].values[0] == 1.2
+    assert "aux1" in mr.data
+    assert mr.data["aux1"].values[0] == 1.1
+    assert "aux2" in mr.data
+    assert mr.data["aux2"].values[0] == 1.2
 
 
 def test_track_aux_items_fail(df_aux):
@@ -141,3 +143,14 @@ def test_track_aux_items_fail(df_aux):
 
     with pytest.raises(ValueError):
         ms.TrackModelResult(df_aux, item="WL", x_item="x", y_item="y", aux_items=["x"])
+
+
+def test_track_to_dataframe(df_aux):
+    mr = ms.TrackModelResult(
+        df_aux, item="WL", x_item="x", y_item="y", aux_items=["aux1"]
+    )
+    df = mr.to_dataframe()
+    assert isinstance(df, pd.DataFrame)
+    # NOTE: aux items are not included in the dataframe
+    assert df.shape == (6, 3)
+    assert list(df.columns) == ["x", "y", "WL"]

--- a/tests/observation/test_point_obs.py
+++ b/tests/observation/test_point_obs.py
@@ -113,9 +113,9 @@ def test_from_df(klagshamn_filename, klagshamn_df):
     o2 = ms.PointObservation(df, item="Water Level", x=366844, y=6154291)
     assert o1.n_points == o2.n_points
 
-    s = o1.data["Klagshamn1"]
+    ser = o1.data["Klagshamn1"]
     # assert isinstance(s, pd.Series)
-    o3 = ms.PointObservation(s, x=366844, y=6154291, name="Klagshamn3")
+    o3 = ms.PointObservation(ser, x=366844, y=6154291, name="Klagshamn3")
     assert o1.n_points == o3.n_points
 
 

--- a/tests/test_aggregated_skill.py
+++ b/tests/test_aggregated_skill.py
@@ -152,9 +152,6 @@ def test_skill_multi_model(cc2):
     # s2 = s.xs("c2", level="observation")
     # assert len(s2.obs_names) == 0
 
-    # s2 = s.sort_index(level="observation")
-    # assert np.all(s2.iloc[0].name == ("SW_1", "EPL"))
-
     # s2 = s.reorder_levels(["observation", "model"])
     # assert np.all(s2.index.levels[0] == s.index.levels[1])
 
@@ -196,6 +193,24 @@ def test_skill_mm_sort_index(cc2):
         "c2",
         "c2",
     ]
+
+
+def test_skill_mm_sort_values(cc2):
+    sk = cc2.skill(metrics=["rmse", "bias"])
+    assert list(sk.index[0]) == ["SW_1", "HKNA"]
+    assert list(sk.index[-1]) == ["SW_2", "c2"]
+
+    sk2 = sk.sort_values("rmse")
+    assert list(sk2.index[0]) == ["SW_1", "EPL"]
+    assert list(sk2.index[-1]) == ["SW_2", "c2"]
+
+    sk3 = sk.sort_values("rmse", ascending=False)
+    assert list(sk3.index[0]) == ["SW_2", "c2"]
+    assert list(sk3.index[-1]) == ["SW_1", "EPL"]
+
+    sk4 = sk.sort_values(["n", "rmse"])
+    assert list(sk4.index[0]) == ["SW_1", "EPL"]
+    assert list(sk4.index[-1]) == ["SW_1", "HKNA"]
 
 
 def test_skill_sel(cc1):

--- a/tests/test_aggregated_skill.py
+++ b/tests/test_aggregated_skill.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 import pandas as pd
 import matplotlib as mpl
@@ -151,20 +152,50 @@ def test_skill_multi_model(cc2):
     # s2 = s.xs("c2", level="observation")
     # assert len(s2.obs_names) == 0
 
-    # s2 = s.swaplevel()
-    # assert np.all(s2.index.levels[0] == s.index.levels[1])
-
-    # s2 = s.head(1)
-    # assert s.iloc[0]["rmse"] == s2.iloc[-1]["rmse"]
-
-    # s2 = s.tail(1)
-    # assert s.iloc[-1]["rmse"] == s2.iloc[0]["rmse"]
-
     # s2 = s.sort_index(level="observation")
     # assert np.all(s2.iloc[0].name == ("SW_1", "EPL"))
 
     # s2 = s.reorder_levels(["observation", "model"])
     # assert np.all(s2.index.levels[0] == s.index.levels[1])
+
+
+def test_skill_mm_swaplevel(cc2):
+    sk = cc2.skill(metrics=["rmse", "bias"])
+    assert list(sk.data.index.names) == ["model", "observation"]
+    sk2 = sk.swaplevel()
+    assert np.all(sk2.index.levels[0] == sk.index.levels[1])
+
+
+def test_skill_mm_sort_index(cc2):
+    sk = cc2.skill(metrics=["rmse", "bias"])
+    assert list(sk.index.get_level_values(1)) == [
+        "HKNA",
+        "EPL",
+        "c2",
+        "HKNA",
+        "EPL",
+        "c2",
+    ]
+
+    sk2 = sk.sort_index(level="observation")
+    assert list(sk2.index.get_level_values(1)) == [
+        "EPL",
+        "EPL",
+        "HKNA",
+        "HKNA",
+        "c2",
+        "c2",
+    ]
+
+    sk3 = sk.swaplevel().sort_index()
+    assert list(sk3.index.get_level_values(0)) == [
+        "EPL",
+        "EPL",
+        "HKNA",
+        "HKNA",
+        "c2",
+        "c2",
+    ]
 
 
 def test_skill_sel(cc1):

--- a/tests/test_comparer.py
+++ b/tests/test_comparer.py
@@ -618,6 +618,39 @@ def test_skill_dt(pc):
     assert list(sk.data.index.levels[1]) == [1, 2, 3, 4, 5]  # Tuesday to Saturday
 
 
+def test_xy_in_skill_pt(pc):
+    # point obs has x,y, track obs x, y are np.nan
+    sk = pc.skill()
+    assert "x" in sk.data.columns
+    assert "y" in sk.data.columns
+    df = sk.data
+    assert all(df.x == pc.x)
+    assert all(df.y == pc.y)
+
+    # x, y maintained on sort_values and similar operations
+    sk2 = sk.sort_values("rmse")
+    assert all(sk2.data.x == pc.x)
+    assert all(sk2.data.y == pc.y)
+
+    sk3 = sk.sort_index()
+    assert all(sk3.data.x == pc.x)
+    assert all(sk3.data.y == pc.y)
+
+    sa = sk.rmse  # SkillArray
+    assert all(sa.data.x == pc.x)
+    assert all(sa.data.y == pc.y)
+
+
+def test_xy_not_in_skill_tc(tc):
+    # point obs has x,y, track obs x, y are np.nan
+    sk = tc.skill()
+    assert "x" in sk.data.columns
+    assert "y" in sk.data.columns
+    df = sk.data
+    assert df.x.isna().all()
+    assert df.y.isna().all()
+
+
 def test_to_dataframe_pt(pc):
     df = pc.to_dataframe()
     assert isinstance(df, pd.DataFrame)

--- a/tests/test_comparer.py
+++ b/tests/test_comparer.py
@@ -627,7 +627,7 @@ def test_xy_in_skill_pt(pc):
     assert all(df.x == pc.x)
     assert all(df.y == pc.y)
 
-    # x, y maintained on sort_values and similar operations
+    # x, y maintained during sort_values, sort_index, sel
     sk2 = sk.sort_values("rmse")
     assert all(sk2.data.x == pc.x)
     assert all(sk2.data.y == pc.y)
@@ -635,6 +635,10 @@ def test_xy_in_skill_pt(pc):
     sk3 = sk.sort_index()
     assert all(sk3.data.x == pc.x)
     assert all(sk3.data.y == pc.y)
+
+    sk4 = sk.sel(model="m1")
+    assert all(sk4.data.x == pc.x)
+    assert all(sk4.data.y == pc.y)
 
     sa = sk.rmse  # SkillArray
     assert all(sa.data.x == pc.x)

--- a/tests/test_comparer.py
+++ b/tests/test_comparer.py
@@ -618,6 +618,20 @@ def test_skill_dt(pc):
     assert list(sk.data.index.levels[1]) == [1, 2, 3, 4, 5]  # Tuesday to Saturday
 
 
+def test_to_dataframe_pt(pc):
+    df = pc.to_dataframe()
+    assert isinstance(df, pd.DataFrame)
+    assert df.shape == (5, 3)
+    assert list(df.columns) == ["Observation", "m1", "m2"]
+
+
+def test_to_dataframe_tc(tc):
+    df = tc.to_dataframe()
+    assert isinstance(df, pd.DataFrame)
+    assert df.shape == (5, 5)
+    assert list(df.columns) == ["x", "y", "Observation", "m1", "m2"]
+
+
 # ======================== plotting ========================
 
 

--- a/tests/test_comparercollection.py
+++ b/tests/test_comparercollection.py
@@ -338,8 +338,8 @@ def test_skill_by_attrs_observed(cc):
 
     sk = cc.skill(by="attrs:use")  # observed=False is default
     assert len(sk) == 2
-    assert sk.data.index[0] is False  # note sorted by df.groupby !
-    assert sk.data.index[1] == "DA"
+    assert sk.data.index[0] == "DA"
+    assert sk.data.index[1] is False
     assert sk.data.index.name == "use"
 
     sk = cc.skill(by="attrs:use", observed=True)

--- a/tests/test_comparercollection.py
+++ b/tests/test_comparercollection.py
@@ -362,6 +362,17 @@ def test_xy_in_skill(cc):
     assert all(df_point.y == cc[0].y)
 
 
+def test_xy_in_skill_no_obs(cc):
+    # if no observation column then no x, y information!
+    # e.g. if we filter by gtype (in this case 1 per obs), no x, y information
+    sk = cc.skill(by=["attrs:gtype", "model"])
+    assert "x" in sk.data.columns
+    assert "y" in sk.data.columns
+    df = sk.data.reset_index()
+    assert df.x.isna().all()
+    assert df.y.isna().all()
+
+
 # ======================== load/save ========================
 
 

--- a/tests/test_comparercollection.py
+++ b/tests/test_comparercollection.py
@@ -348,6 +348,20 @@ def test_skill_by_attrs_observed(cc):
     assert sk.data.index.name == "use"
 
 
+def test_xy_in_skill(cc):
+    # point obs has x,y, track obs x, y are np.nan
+    sk = cc.skill()
+    assert "x" in sk.data.columns
+    assert "y" in sk.data.columns
+    df = sk.data.reset_index()
+    df_track = df.loc[df.observation == "fake track obs"]
+    assert df_track.x.isna().all()
+    assert df_track.y.isna().all()
+    df_point = df.loc[df.observation == "fake point obs"]
+    assert all(df_point.x == cc[0].x)
+    assert all(df_point.y == cc[0].y)
+
+
 # ======================== load/save ========================
 
 

--- a/tests/test_grid_skill.py
+++ b/tests/test_grid_skill.py
@@ -61,54 +61,54 @@ def test_spatial_skill_deprecated(cmp1) -> None:
 
 
 def test_gridded_skill_multi_model(cc2) -> None:
-    ss = cc2.gridded_skill(bins=3, metrics=["rmse", "bias"])
-    assert len(ss.x) == 3
-    assert len(ss.y) == 3
-    assert len(ss.mod_names) == 2
-    assert len(ss.obs_names) == 3
-    assert len(ss.metrics) == 3
+    gs = cc2.gridded_skill(bins=3, metrics=["rmse", "bias"])
+    assert len(gs.x) == 3
+    assert len(gs.y) == 3
+    assert len(gs.mod_names) == 2
+    assert len(gs.obs_names) == 3
+    assert len(gs.metrics) == 3
 
 
 def test_gridded_skill_sel_model(cc2) -> None:
-    ss = cc2.gridded_skill(bins=3, metrics=["rmse", "bias"])
-    ss2 = ss.sel(model="SW_1")
-    ss2.rmse.plot()
+    gs = cc2.gridded_skill(bins=3, metrics=["rmse", "bias"])
+    gs2 = gs.sel(model="SW_1")
+    gs2.rmse.plot()
 
     with pytest.raises(KeyError):
-        ss.sel(model="bad_model")
+        gs.sel(model="bad_model")
 
 
 def test_gridded_skill_is_subsettable(cc2) -> None:
-    ss = cc2.gridded_skill(bins=3, metrics=["rmse", "bias"])
-    ss.data.rmse.sel(x=2, y=53.5, method="nearest").values == pytest.approx(0.10411702)
+    gs = cc2.gridded_skill(bins=3, metrics=["rmse", "bias"])
+    gs.data.rmse.sel(x=2, y=53.5, method="nearest").values == pytest.approx(0.10411702)
 
     cmp = cc2[0]
 
-    ss2 = cmp.gridded_skill(bins=3, metrics=["rmse", "bias"])
-    ss2.data.rmse.sel(x=2, y=53.5, method="nearest").values == pytest.approx(0.10411702)
+    gs2 = cmp.gridded_skill(bins=3, metrics=["rmse", "bias"])
+    gs2.data.rmse.sel(x=2, y=53.5, method="nearest").values == pytest.approx(0.10411702)
 
 
 def test_gridded_skill_plot(cmp1) -> None:
-    ss = cmp1.gridded_skill(metrics=["rmse", "bias"])
-    ss.bias.plot()
+    gs = cmp1.gridded_skill(metrics=["rmse", "bias"])
+    gs.bias.plot()
 
     with pytest.warns(FutureWarning, match="deprecated"):
-        ss.plot("bias")
+        gs.plot("bias")
 
 
 def test_gridded_skill_plot_multi_model(cc2) -> None:
-    ss = cc2.gridded_skill(by=["model"], metrics=["rmse", "bias"])
-    ss["bias"].plot()
+    gs = cc2.gridded_skill(by=["model"], metrics=["rmse", "bias"])
+    gs["bias"].plot()
 
     with pytest.warns(FutureWarning, match="deprecated"):
-        ss["rmse"].plot(model="SW_1")
+        gs["rmse"].plot(model="SW_1")
 
 
 def test_gridded_skill_plot_multi_model_fails(cc2) -> None:
-    ss = cc2.gridded_skill(by=["model"], metrics=["rmse", "bias"])
+    gs = cc2.gridded_skill(by=["model"], metrics=["rmse", "bias"])
     with pytest.raises(KeyError):
-        ss["bad_metric"]
+        gs["bad_metric"]
 
     with pytest.raises(ValueError):
         with pytest.warns(FutureWarning, match="deprecated"):
-            ss.rmse.plot(model="bad_model")
+            gs.rmse.plot(model="bad_model")

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -275,8 +275,8 @@ def test_matched_data_not_time_index():
     cmp.plot.scatter()
 
     # skill metrics do not care about time
-    s = cmp.skill(metrics="mae")
-    assert s.loc["sensor_a", "mae"] == pytest.approx(1.0)
+    sk = cmp.skill(metrics="mae")
+    assert sk.loc["sensor_a", "mae"] == pytest.approx(1.0)
 
     cmp.plot.timeseries()
 

--- a/tests/test_multimodelcompare.py
+++ b/tests/test_multimodelcompare.py
@@ -113,16 +113,16 @@ def test_mm_sel_missing_model(cc):
 
 def test_mm_skill_obs(cc):
     with pytest.warns(FutureWarning):
-        s = cc.skill(observation="c2")
-        assert len(s) == 2
-        assert pytest.approx(s.loc["SW_2"].bias) == 0.081431053
+        sk = cc.skill(observation="c2")
+        assert len(sk) == 2
+        assert pytest.approx(sk.loc["SW_2"].bias) == 0.081431053
 
-    s = cc.sel(observation="c2").skill()
-    assert len(s) == 2
-    assert pytest.approx(s.loc["SW_2"].bias) == 0.081431053
+    sk = cc.sel(observation="c2").skill()
+    assert len(sk) == 2
+    assert pytest.approx(sk.loc["SW_2"].bias) == 0.081431053
 
-    s2 = cc.sel(observation=-1).skill()
-    assert s.loc["SW_2"].bias == s2.loc["SW_2"].bias
+    sk2 = cc.sel(observation=-1).skill()
+    assert sk.loc["SW_2"].bias == sk2.loc["SW_2"].bias
 
 
 def test_mm_mean_skill_obs(cc):
@@ -143,45 +143,45 @@ def test_mm_sel_missing_obs(cc, o1):
 
 def test_mm_skill_start_end(cc):
     # TODO should we keep these tests?
-    s = cc.sel(model="SW_1", start="2017").skill()
-    assert s.loc["EPL"].n == 67
-    s = cc.sel(model="SW_1", end="2017-10-28 00:00:00").skill()
-    assert s.loc["EPL"].n == 25
-    s = cc.sel(model="SW_1", start="2017-10-28 00:00:01").skill()
-    assert s.loc["EPL"].n == 42
+    sk = cc.sel(model="SW_1", start="2017").skill()
+    assert sk.loc["EPL"].n == 67
+    sk = cc.sel(model="SW_1", end="2017-10-28 00:00:00").skill()
+    assert sk.loc["EPL"].n == 25
+    sk = cc.sel(model="SW_1", start="2017-10-28 00:00:01").skill()
+    assert sk.loc["EPL"].n == 42
 
 
 def test_mm_skill_area_bbox(cc):
     bbox = [0.5, 52.5, 5, 54]
-    s = cc.sel(model="SW_1", area=bbox).skill()
-    assert pytest.approx(s.loc["HKNA"].urmse) == 0.293498777
+    sk = cc.sel(model="SW_1", area=bbox).skill()
+    assert pytest.approx(sk.loc["HKNA"].urmse) == 0.293498777
     bbox = np.array([0.5, 52.5, 5, 54])
-    s = cc.sel(model="SW_1", area=bbox).skill()
-    assert pytest.approx(s.loc["HKNA"].urmse) == 0.293498777
+    sk = cc.sel(model="SW_1", area=bbox).skill()
+    assert pytest.approx(sk.loc["HKNA"].urmse) == 0.293498777
 
 
 def test_mm_skill_area_polygon(cc):
     polygon = np.array([[6, 51], [0, 55], [0, 51], [6, 51]])
-    s = cc.sel(model="SW_2", area=polygon).skill()
-    assert "HKNA" not in s.obs_names
-    assert s.to_dataframe().iloc[1].n == 66
+    sk = cc.sel(model="SW_2", area=polygon).skill()
+    assert "HKNA" not in sk.obs_names
+    assert sk.to_dataframe().iloc[1].n == 66
 
     # "this is not the indexing you want..."
     # assert pytest.approx(s.iloc[0].r2) == 0.9271339372
 
     # same as above but not closed
     polygon = np.array([[6, 51], [0, 55], [0, 51]])
-    s = cc.sel(model="SW_2", area=polygon).skill()
+    sk = cc.sel(model="SW_2", area=polygon).skill()
 
     # assert pytest.approx(s.iloc[0].r2) == 0.9271339372
 
     polygon = [6, 51, 0, 55, 0, 51, 6, 51]
-    s = cc.sel(model="SW_2", area=polygon).skill()
+    sk = cc.sel(model="SW_2", area=polygon).skill()
     # assert pytest.approx(s.iloc[0].r2) == 0.9271339372
 
     # same as above but not closed
     polygon = [6, 51, 0, 55, 0, 51]
-    s = cc.sel(model="SW_2", area=polygon).skill()
+    sk = cc.sel(model="SW_2", area=polygon).skill()
     # assert pytest.approx(s.iloc[0].r2) == 0.9271339372
 
 
@@ -190,12 +190,12 @@ def test_mm_mean_skill_area_polygon(cc):
     # It also states that if the exterior linear ring of a polygon is defined in a counterclockwise direction, then it will be seen from the "top".
     # Any interior linear rings should be defined in opposite fashion compared to the exterior ring, in this case, clockwise
     polygon = np.array([[6, 51], [0, 55], [0, 51], [6, 51]])
-    s = cc.sel(area=polygon).mean_skill()
-    assert pytest.approx(s.loc["SW_2"].rmse) == 0.3349027897
+    sk = cc.sel(area=polygon).mean_skill()
+    assert pytest.approx(sk.loc["SW_2"].rmse) == 0.3349027897
 
     closed_polygon = ((6, 51), (0, 55), (0, 51), (6, 51))
-    s2 = cc.sel(area=closed_polygon).mean_skill()
-    assert pytest.approx(s2.loc["SW_2"].rmse) == 0.3349027897
+    sk2 = cc.sel(area=closed_polygon).mean_skill()
+    assert pytest.approx(sk2.loc["SW_2"].rmse) == 0.3349027897
 
     # TODO support for polygons with holes
 
@@ -219,9 +219,9 @@ def test_mm_skill_metrics(cc):
     df = cc.sel(model="SW_1").skill(metrics=[mtr.mean_absolute_error]).to_dataframe()
     assert df.mean_absolute_error.values.sum() > 0.0
 
-    s = cc.sel(model="SW_1").skill(metrics=[mtr.bias, "rmse"])
-    assert pytest.approx(s.loc["EPL"].bias) == -0.06659714
-    assert pytest.approx(s.loc["EPL"].rmse) == 0.22359664
+    sk = cc.sel(model="SW_1").skill(metrics=[mtr.bias, "rmse"])
+    assert pytest.approx(sk.loc["EPL"].bias) == -0.06659714
+    assert pytest.approx(sk.loc["EPL"].rmse) == 0.22359664
 
     with pytest.raises(ValueError):
         cc.sel(model="SW_1").skill(metrics=["mean_se"])
@@ -232,22 +232,22 @@ def test_mm_skill_metrics(cc):
 
 
 def test_mm_mean_skill(cc):
-    s = cc.mean_skill()
-    assert len(s) == 2
-    assert s.loc["SW_1"].rmse == pytest.approx(0.309118939)
+    sk = cc.mean_skill()
+    assert len(sk) == 2
+    assert sk.loc["SW_1"].rmse == pytest.approx(0.309118939)
 
 
 def test_mm_mean_skill_weights_list(cc):
-    s = cc.mean_skill(weights=[0.3, 0.2, 1.0])
-    assert len(s) == 2
-    assert s.loc["SW_1"].rmse == pytest.approx(0.3261788143)
+    sk = cc.mean_skill(weights=[0.3, 0.2, 1.0])
+    assert len(sk) == 2
+    assert sk.loc["SW_1"].rmse == pytest.approx(0.3261788143)
 
-    s = cc.mean_skill(weights=[100000000000.0, 1.0, 1.0])
-    assert s.loc["SW_1"].rmse < 1.0
+    sk = cc.mean_skill(weights=[100000000000.0, 1.0, 1.0])
+    assert sk.loc["SW_1"].rmse < 1.0
 
-    s = cc.mean_skill(weights=1)
-    assert len(s) == 2
-    assert s.loc["SW_1"].rmse == pytest.approx(0.309118939)
+    sk = cc.mean_skill(weights=1)
+    assert len(sk) == 2
+    assert sk.loc["SW_1"].rmse == pytest.approx(0.309118939)
 
     with pytest.raises(ValueError):
         # too many weights
@@ -255,19 +255,19 @@ def test_mm_mean_skill_weights_list(cc):
 
 
 def test_mm_mean_skill_weights_str(cc):
-    s = cc.mean_skill(weights="points")
-    assert len(s) == 2
-    assert s.loc["SW_1"].rmse == pytest.approx(0.3367349)
+    sk = cc.mean_skill(weights="points")
+    assert len(sk) == 2
+    assert sk.loc["SW_1"].rmse == pytest.approx(0.3367349)
 
-    s = cc.mean_skill(weights="equal")
-    assert len(s) == 2
-    assert s.loc["SW_1"].rmse == pytest.approx(0.309118939)
+    sk = cc.mean_skill(weights="equal")
+    assert len(sk) == 2
+    assert sk.loc["SW_1"].rmse == pytest.approx(0.309118939)
 
 
 def test_mm_mean_skill_weights_dict(cc):
-    s = cc.mean_skill(weights={"EPL": 0.2, "c2": 1.0, "HKNA": 0.3})
-    df = s.to_dataframe()
-    assert len(s) == 2
+    sk = cc.mean_skill(weights={"EPL": 0.2, "c2": 1.0, "HKNA": 0.3})
+    df = sk.to_dataframe()
+    assert len(sk) == 2
     assert df.loc["SW_1"].rmse == pytest.approx(0.3261788143)
 
     # s2 = cc.mean_skill(weights=[0.3, 0.2, 1.0])
@@ -277,7 +277,7 @@ def test_mm_mean_skill_weights_dict(cc):
     # assert s.loc["SW_2"].rmse == s2.loc["SW_2"].rmse
 
     df = cc.mean_skill(weights={"EPL": 2.0}).to_dataframe()
-    assert len(s) == 2
+    assert len(sk) == 2
     assert df.loc["SW_1"].rmse == pytest.approx(0.319830126)
 
     # df2 = cc.mean_skill(weights={"EPL": 2.0, "c2": 1.0, "HKNA": 1.0}).to_dataframe()
@@ -289,9 +289,9 @@ def test_mm_mean_skill_weights_dict(cc):
 
 # TODO: mean_skill_points needs fixing before this test can be enabled
 # def test_mean_skill_points(cc):
-#     s = cc.mean_skill_points()
-#     assert len(s) == 2
-#     assert s.loc["SW_1"].rmse == pytest.approx(0.33927729)
+#     sk = cc.mean_skill_points()
+#     assert len(sk) == 2
+#     assert sk.loc["SW_1"].rmse == pytest.approx(0.33927729)
 
 
 def test_mm_scatter(cc):
@@ -353,12 +353,12 @@ def test_custom_metric_skilltable_mm_scatter(cc):
     assert mtr.is_valid_metric("cm_1")
 
     # use custom metric as function
-    s = cc.skill(metrics=[cm_1])
-    assert s["cm_1"] is not None
+    sk = cc.skill(metrics=[cm_1])
+    assert sk["cm_1"] is not None
 
     # use custom metric as string
     cc.skill(metrics=["cm_1"])
-    assert s["cm_1"] is not None
+    assert sk["cm_1"] is not None
 
     # using a non-registred metric raises an error, even though it is a defined function, but not registered
     with pytest.raises(ValueError) as e_info:

--- a/tests/test_multimodelcompare.py
+++ b/tests/test_multimodelcompare.py
@@ -78,17 +78,18 @@ def test_add_same_comparer_twice(mr1, mr2, o1, o2):
 def test_mm_skill(cc):
     df = cc.sel(start="2017-10-27 00:01").skill().to_dataframe()
 
-    assert df.iloc[4].name[0] == "SW_2"
-    assert df.iloc[4].name[1] == "HKNA"
-    assert pytest.approx(df.iloc[4].mae, 1e-5) == 0.214476
+    # mod: ['SW_1', 'SW_2'], obs: ['HKNA', 'EPL', 'c2']
+    assert df.iloc[3].name[0] == "SW_2"
+    assert df.iloc[3].name[1] == "HKNA"
+    assert pytest.approx(df.iloc[3].mae, 1e-5) == 0.214476
 
     # TODO remove in v1.1
     with pytest.warns(FutureWarning):
         df = cc.skill(start="2017-10-27 00:01").to_dataframe()
 
-    assert df.iloc[4].name[0] == "SW_2"
-    assert df.iloc[4].name[1] == "HKNA"
-    assert pytest.approx(df.iloc[4].mae, 1e-5) == 0.214476
+    assert df.iloc[3].name[0] == "SW_2"
+    assert df.iloc[3].name[1] == "HKNA"
+    assert pytest.approx(df.iloc[3].mae, 1e-5) == 0.214476
 
 
 def test_mm_skill_model(cc):
@@ -238,7 +239,7 @@ def test_mm_mean_skill(cc):
 
 
 def test_mm_mean_skill_weights_list(cc):
-    sk = cc.mean_skill(weights=[0.3, 0.2, 1.0])
+    sk = cc.mean_skill(weights=[0.2, 0.3, 1.0])
     assert len(sk) == 2
     assert sk.loc["SW_1"].rmse == pytest.approx(0.3261788143)
 
@@ -265,7 +266,7 @@ def test_mm_mean_skill_weights_str(cc):
 
 
 def test_mm_mean_skill_weights_dict(cc):
-    sk = cc.mean_skill(weights={"EPL": 0.2, "c2": 1.0, "HKNA": 0.3})
+    sk = cc.mean_skill(weights={"EPL": 0.3, "c2": 1.0, "HKNA": 0.2})
     df = sk.to_dataframe()
     assert len(sk) == 2
     assert df.loc["SW_1"].rmse == pytest.approx(0.3261788143)
@@ -276,7 +277,7 @@ def test_mm_mean_skill_weights_dict(cc):
     # assert s.loc["SW_1"].rmse == s2.loc["SW_1"].rmse
     # assert s.loc["SW_2"].rmse == s2.loc["SW_2"].rmse
 
-    df = cc.mean_skill(weights={"EPL": 2.0}).to_dataframe()
+    df = cc.mean_skill(weights={"HKNA": 2.0}).to_dataframe()
     assert len(sk) == 2
     assert df.loc["SW_1"].rmse == pytest.approx(0.319830126)
 

--- a/tests/test_multivariable_compare.py
+++ b/tests/test_multivariable_compare.py
@@ -86,9 +86,10 @@ def test_n_quantities(cc):
 
 def test_mv_skill(cc_1model):
     df = cc_1model.skill().to_dataframe()
+    assert list(df.reset_index().observation) == cc_1model.obs_names
     assert df.index.names[0] == "observation"
     assert df.index.names[1] == "quantity"
-    assert pytest.approx(df.iloc[0].rmse) == 0.22359663
+    assert pytest.approx(df.iloc[1].rmse) == 0.22359663
     idx = ("HKNA_wind", "Wind speed")
     assert pytest.approx(df.loc[idx].rmse) == 1.27617894455
 
@@ -104,7 +105,7 @@ def test_mv_mm_skill(cc):
     df = cc.sel(model="SW_1").skill().to_dataframe()
     assert df.index.names[0] == "observation"
     assert df.index.names[1] == "quantity"
-    assert pytest.approx(df.iloc[0].rmse) == 0.22359663
+    assert pytest.approx(df.iloc[1].rmse) == 0.22359663
     idx = ("HKNA_wind", "Wind speed")
     assert pytest.approx(df.loc[idx].rmse) == 1.27617894455
 

--- a/tests/test_pointcompare.py
+++ b/tests/test_pointcompare.py
@@ -190,7 +190,7 @@ def test_weighted_score_from_prematched():
     assert cc["klagshamn"].weight == 100.0
     assert cc["drogden"].weight == 0.0
 
-    assert cc.score()["Oresund"] == pytest.approx(1.0)
+    assert cc.score()["Oresund"] == pytest.approx(0.0)  # 100 * 0 + 0 * 1
 
 
 def test_misc_properties(klagshamn, drogden):

--- a/tests/test_pointcompare.py
+++ b/tests/test_pointcompare.py
@@ -108,8 +108,8 @@ def test_score(modelresult_oresund_WL, klagshamn, drogden):
     assert cc.score(metric=root_mean_squared_error)[
         "Oresund2D_subset"
     ] == pytest.approx(0.1986296276629835)
-    s = cc.skill(metrics=[root_mean_squared_error, mean_absolute_error])
-    s.root_mean_squared_error.data.mean() == pytest.approx(0.1986296276629835)
+    sk = cc.skill(metrics=[root_mean_squared_error, mean_absolute_error])
+    sk.root_mean_squared_error.data.mean() == pytest.approx(0.1986296276629835)
 
 
 def test_weighted_score(modelresult_oresund_WL):

--- a/tests/test_trackcompare.py
+++ b/tests/test_trackcompare.py
@@ -185,8 +185,9 @@ def test_tiny_mod_xy_difference(obs_tiny_df, mod_tiny_unique):
             obs_tiny_df, item="alti", x_item="x", y_item="y", keep_duplicates="first"
         )
     with pytest.warns(UserWarning, match="Removed 2 model points"):
+        # 2 points removed due to difference in x,y
         cmp = ms.match(obs_tiny, mod_tiny_unique)
-    assert cmp.n_points == 2  # 2 points removed due to difference in x,y
+    assert cmp.n_points == 2
     expected_time = pd.DatetimeIndex(
         [
             "2017-10-27 13:00:02",

--- a/tests/test_trackcompare.py
+++ b/tests/test_trackcompare.py
@@ -184,7 +184,8 @@ def test_tiny_mod_xy_difference(obs_tiny_df, mod_tiny_unique):
         obs_tiny = ms.TrackObservation(
             obs_tiny_df, item="alti", x_item="x", y_item="y", keep_duplicates="first"
         )
-    cmp = ms.match(obs_tiny, mod_tiny_unique)
+    with pytest.warns(UserWarning, match="Removed 2 model points"):
+        cmp = ms.match(obs_tiny, mod_tiny_unique)
     assert cmp.n_points == 2  # 2 points removed due to difference in x,y
     expected_time = pd.DatetimeIndex(
         [


### PR DESCRIPTION
* groupby(..., sort=False) in skill() and similar methods
    * correct tests accordingly
* Fix bug in weights when assigning from dict (caused wrong results in some cases)
* Re-introduce to_dataframe() on Comparer
* Syncronize to_dataframe() of Comparer and Timeseries such that they work in the same way (include aux also)
* Docstrings for all to_dataframe() methods
* Docstrings for several other methods
* Renaming of internal variables (and variables in tests) to confirm to best practice and for consistency (e.g. sk for skill() )
* New method sort_values() on SkillTable
* xy set to nan for skill() of track data