### PR TITLE
Spatial interp method

### DIFF
--- a/modelskill/connection.py
+++ b/modelskill/connection.py
@@ -183,7 +183,7 @@ class SingleObsConnector:
         else:
             raise ValueError(f"Unknown observation type {type(obs)}")
 
-    def extract(self, *args, **kwargs) -> Optional[Comparer]:
+    def extract(self, **kwargs) -> Optional[Comparer]:
         """Extract model results at times and positions of observation.
 
         Returns
@@ -191,9 +191,7 @@ class SingleObsConnector:
         Comparer
             A comparer object for further analysis and plotting.
         """
-        comparer = _single_obs_compare(
-            obs=self.obs, mod=self.modelresults, *args, **kwargs
-        )
+        comparer = _single_obs_compare(obs=self.obs, mod=self.modelresults, **kwargs)
         if comparer.n_points == 0:
             warnings.warn(f"No overlapping data was found for {comparer.name}!")
             return None

--- a/modelskill/connection.py
+++ b/modelskill/connection.py
@@ -183,7 +183,7 @@ class SingleObsConnector:
         else:
             raise ValueError(f"Unknown observation type {type(obs)}")
 
-    def extract(self, max_model_gap: Optional[float] = None) -> Optional[Comparer]:
+    def extract(self, *args, **kwargs) -> Optional[Comparer]:
         """Extract model results at times and positions of observation.
 
         Returns
@@ -192,7 +192,7 @@ class SingleObsConnector:
             A comparer object for further analysis and plotting.
         """
         comparer = _single_obs_compare(
-            obs=self.obs, mod=self.modelresults, max_model_gap=max_model_gap
+            obs=self.obs, mod=self.modelresults, *args, **kwargs
         )
         if comparer.n_points == 0:
             warnings.warn(f"No overlapping data was found for {comparer.name}!")

--- a/modelskill/matching.py
+++ b/modelskill/matching.py
@@ -6,6 +6,7 @@ import warnings
 from typing import (
     Dict,
     Iterable,
+    Collection,
     List,
     Literal,
     Optional,
@@ -230,9 +231,9 @@ def match(
             spatial_interp_method=spatial_interp_method,
         )
 
-    assert isinstance(obs, Iterable)
+    assert isinstance(obs, Collection)
 
-    if len(obs) > 1 and isinstance(mod, Iterable) and len(mod) > 1:
+    if len(obs) > 1 and isinstance(mod, Collection) and len(mod) > 1:
         if not all(isinstance(m, (DfsuModelResult, GridModelResult)) for m in mod):
             raise ValueError(
                 """

--- a/modelskill/matching.py
+++ b/modelskill/matching.py
@@ -160,7 +160,7 @@ def match(
     mod_item: Optional[IdxOrNameTypes] = None,
     gtype: Optional[GeometryTypes] = None,
     max_model_gap: Optional[float] = None,
-    spatial_interp_method: Optional[str] = None,
+    spatial_method: Optional[str] = None,
 ) -> Comparer:
     ...
 
@@ -174,7 +174,7 @@ def match(
     mod_item: Optional[IdxOrNameTypes] = None,
     gtype: Optional[GeometryTypes] = None,
     max_model_gap: Optional[float] = None,
-    spatial_interp_method: Optional[str] = None,
+    spatial_method: Optional[str] = None,
 ) -> ComparerCollection:
     ...
 
@@ -187,7 +187,7 @@ def match(
     mod_item=None,
     gtype=None,
     max_model_gap=None,
-    spatial_interp_method: Optional[str] = None,
+    spatial_method: Optional[str] = None,
 ):
     """Match observation and model result data in space and time
 
@@ -214,10 +214,10 @@ def match(
     max_model_gap : (float, optional)
         Maximum time gap (s) in the model result (e.g. for event-based
         model results), by default None
-    spatial_interp_method : str, optional
+    spatial_method : str, optional
         For Dfsu- and GridModelResult, spatial interpolation/selection method.
 
-        - For DfsuModelResult, one of: 'contained' (=isel), 'nearest' (not recommended), 
+        - For DfsuModelResult, one of: 'contained' (=isel), 'nearest' (not recommended),
         'inverse_distance' (with 5 nearest points), by default "inverse_distance".
         - For GridModelResult, passed to xarray.interp() as method argument,
         by default "linear".
@@ -242,7 +242,7 @@ def match(
             mod_item=mod_item,
             gtype=gtype,
             max_model_gap=max_model_gap,
-            spatial_interp_method=spatial_interp_method,
+            spatial_method=spatial_method,
         )
 
     assert isinstance(obs, Collection)
@@ -269,7 +269,7 @@ def match(
             mod_item=mod_item,
             gtype=gtype,
             max_model_gap=max_model_gap,
-            spatial_interp_method=spatial_interp_method,
+            spatial_method=spatial_method,
         )
         for o in obs
     ]
@@ -313,14 +313,14 @@ def _single_obs_compare(
     mod_item: Optional[int | str] = None,
     gtype: Optional[GeometryTypes] = None,
     max_model_gap: Optional[float] = None,
-    spatial_interp_method: Optional[str] = None,
+    spatial_method: Optional[str] = None,
 ) -> Comparer:
     """Compare a single observation with multiple models"""
     obs = _parse_single_obs(obs, obs_item, gtype=gtype)
 
     mods = _parse_models(mod, mod_item, gtype=gtype)
 
-    raw_mod_data = {m.name: m.extract(obs, spatial_interp_method) for m in mods}
+    raw_mod_data = {m.name: m.extract(obs, spatial_method) for m in mods}
     matched_data = match_space_time(obs, raw_mod_data, max_model_gap)
     matched_data.attrs["weight"] = obs.weight
 

--- a/modelskill/matching.py
+++ b/modelskill/matching.py
@@ -207,6 +207,14 @@ def match(
     max_model_gap : (float, optional)
         Maximum time gap (s) in the model result (e.g. for event-based
         model results), by default None
+    spatial_interp_method : str, optional
+        For Dfsu- and GridModelResult, spatial interpolation method,
+        by default None.
+
+        - For DfsuModelResult, one of: 'nearest', 'contained' (=isel),
+        'inverse_distance' (with 4 nearest points)
+        - For GridModelResult, passed to xarray.interp() as method argument,
+        by default None="linear"
 
     Returns
     -------

--- a/modelskill/matching.py
+++ b/modelskill/matching.py
@@ -215,13 +215,12 @@ def match(
         Maximum time gap (s) in the model result (e.g. for event-based
         model results), by default None
     spatial_interp_method : str, optional
-        For Dfsu- and GridModelResult, spatial interpolation method,
-        by default None.
+        For Dfsu- and GridModelResult, spatial interpolation/selection method.
 
-        - For DfsuModelResult, one of: 'nearest', 'contained' (=isel),
-        'inverse_distance' (with 4 nearest points)
+        - For DfsuModelResult, one of: 'contained' (=isel), 'nearest' (not recommended), 
+        'inverse_distance' (with 5 nearest points), by default "inverse_distance".
         - For GridModelResult, passed to xarray.interp() as method argument,
-        by default None="linear"
+        by default "linear".
 
     Returns
     -------

--- a/modelskill/matching.py
+++ b/modelskill/matching.py
@@ -159,6 +159,7 @@ def match(
     mod_item: Optional[IdxOrNameTypes] = None,
     gtype: Optional[GeometryTypes] = None,
     max_model_gap: Optional[float] = None,
+    spatial_interp_method: Optional[str] = None,
 ) -> Comparer:
     ...
 
@@ -172,6 +173,7 @@ def match(
     mod_item: Optional[IdxOrNameTypes] = None,
     gtype: Optional[GeometryTypes] = None,
     max_model_gap: Optional[float] = None,
+    spatial_interp_method: Optional[str] = None,
 ) -> ComparerCollection:
     ...
 
@@ -184,6 +186,7 @@ def match(
     mod_item=None,
     gtype=None,
     max_model_gap=None,
+    spatial_interp_method: Optional[str] = None,
 ):
     """Compare observations and model results
 
@@ -224,6 +227,7 @@ def match(
             mod_item=mod_item,
             gtype=gtype,
             max_model_gap=max_model_gap,
+            spatial_interp_method=spatial_interp_method,
         )
 
     assert isinstance(obs, Iterable)
@@ -250,6 +254,7 @@ def match(
             mod_item=mod_item,
             gtype=gtype,
             max_model_gap=max_model_gap,
+            spatial_interp_method=spatial_interp_method,
         )
         for o in obs
     ]
@@ -293,13 +298,14 @@ def _single_obs_compare(
     mod_item: Optional[int | str] = None,
     gtype: Optional[GeometryTypes] = None,
     max_model_gap: Optional[float] = None,
+    spatial_interp_method: Optional[str] = None,
 ) -> Comparer:
     """Compare a single observation with multiple models"""
     obs = _parse_single_obs(obs, obs_item, gtype=gtype)
 
     mods = _parse_models(mod, mod_item, gtype=gtype)
 
-    raw_mod_data = {m.name: m.extract(obs) for m in mods}
+    raw_mod_data = {m.name: m.extract(obs, spatial_interp_method) for m in mods}
     matched_data = match_space_time(obs, raw_mod_data, max_model_gap)
     matched_data.attrs["weight"] = obs.weight
 

--- a/modelskill/matching.py
+++ b/modelskill/matching.py
@@ -217,10 +217,10 @@ def match(
     spatial_method : str, optional
         For Dfsu- and GridModelResult, spatial interpolation/selection method.
 
-        - For DfsuModelResult, one of: 'contained' (=isel), 'nearest' (not recommended),
+        - For DfsuModelResult, one of: 'contained' (=isel), 'nearest',
         'inverse_distance' (with 5 nearest points), by default "inverse_distance".
         - For GridModelResult, passed to xarray.interp() as method argument,
-        by default "linear".
+        by default 'linear'.
 
     Returns
     -------

--- a/modelskill/model/_base.py
+++ b/modelskill/model/_base.py
@@ -79,12 +79,12 @@ class SpatialField(Protocol):
     ) -> PointModelResult | TrackModelResult:
         ...
 
-    def extract_point(
+    def _extract_point(
         self, observation: PointObservation, spatial_interp_method: Optional[str] = None
     ) -> PointModelResult:
         ...
 
-    def extract_track(
+    def _extract_track(
         self, observation: TrackObservation, spatial_interp_method: Optional[str] = None
     ) -> TrackModelResult:
         ...

--- a/modelskill/model/_base.py
+++ b/modelskill/model/_base.py
@@ -75,16 +75,16 @@ class SpatialField(Protocol):
     def extract(
         self,
         observation: PointObservation | TrackObservation,
-        spatial_interp_method: Optional[str] = None,
+        spatial_method: Optional[str] = None,
     ) -> PointModelResult | TrackModelResult:
         ...
 
     def _extract_point(
-        self, observation: PointObservation, spatial_interp_method: Optional[str] = None
+        self, observation: PointObservation, spatial_method: Optional[str] = None
     ) -> PointModelResult:
         ...
 
     def _extract_track(
-        self, observation: TrackObservation, spatial_interp_method: Optional[str] = None
+        self, observation: TrackObservation, spatial_method: Optional[str] = None
     ) -> TrackModelResult:
         ...

--- a/modelskill/model/_base.py
+++ b/modelskill/model/_base.py
@@ -73,12 +73,18 @@ def _validate_overlap_in_time(time: pd.DatetimeIndex, observation: Observation) 
 
 class SpatialField(Protocol):
     def extract(
-        self, observation: PointObservation | TrackObservation
+        self,
+        observation: PointObservation | TrackObservation,
+        spatial_interp_method: Optional[str] = None,
     ) -> PointModelResult | TrackModelResult:
         ...
 
-    def extract_point(self, observation: PointObservation) -> PointModelResult:
+    def extract_point(
+        self, observation: PointObservation, spatial_interp_method: Optional[str] = None
+    ) -> PointModelResult:
         ...
 
-    def extract_track(self, observation: TrackObservation) -> TrackModelResult:
+    def extract_track(
+        self, observation: TrackObservation, spatial_interp_method: Optional[str] = None
+    ) -> TrackModelResult:
         ...

--- a/modelskill/model/dfsu.py
+++ b/modelskill/model/dfsu.py
@@ -110,13 +110,13 @@ class DfsuModelResult(SpatialField):
         observation : <PointObservation> or <TrackObservation>
             positions (and times) at which modelresult should be extracted
         spatial_method : Optional[str], optional
-            spatial interpolation method, 'nearest', 'contained' (=isel),
+            spatial selection/interpolation method, 'nearest', 'contained' (=isel),
             'inverse_distance' (with 3 nearest points), by default None = 'contained'
 
         Returns
         -------
         PointModelResult or TrackModelResult
-            extracted modelresult
+            extracted modelresult with the same geometry as the observation
         """
         method = self._parse_spatial_method(spatial_method)
 

--- a/modelskill/model/dfsu.py
+++ b/modelskill/model/dfsu.py
@@ -103,6 +103,8 @@ class DfsuModelResult(SpatialField):
     ) -> PointModelResult | TrackModelResult:
         """Extract ModelResult at observation positions
 
+        Note: this method is typically not called directly, but through the match() method.
+
         Parameters
         ----------
         observation : <PointObservation> or <TrackObservation>

--- a/modelskill/model/dfsu.py
+++ b/modelskill/model/dfsu.py
@@ -147,8 +147,11 @@ class DfsuModelResult(SpatialField):
     def _extract_point(
         self, observation: PointObservation, spatial_method: Optional[str] = None
     ) -> PointModelResult:
-        """Spatially extract a PointModelResult from a DfsuModelResult (when data is a Dfsu object),
-        given a PointObservation. No time interpolation is done!"""
+        """Spatially extract a PointModelResult from a DfsuModelResult
+        given a PointObservation. No time interpolation is done!
+
+        Note: 'inverse_distance' method uses 5 nearest points and is the default.
+        """
 
         method = spatial_method or "contained"
         assert method in ["nearest", "contained", "inverse_distance"]
@@ -221,7 +224,7 @@ class DfsuModelResult(SpatialField):
 
         MIKE IO's extract_track, inverse_distance method, uses 5 nearest points.
         """
-        method = spatial_method or "nearest"
+        method = spatial_method or "inverse_distance"
         if method == "contained":
             raise NotImplementedError(
                 "spatial method 'contained' (=isel) not implemented for track extraction in MIKE IO"

--- a/modelskill/model/dfsu.py
+++ b/modelskill/model/dfsu.py
@@ -103,15 +103,16 @@ class DfsuModelResult(SpatialField):
     ) -> PointModelResult | TrackModelResult:
         """Extract ModelResult at observation positions
 
-        Note: this method is typically not called directly, but through the match() method.
+        Note: this method is typically not called directly, but by the match() method.
 
         Parameters
         ----------
         observation : <PointObservation> or <TrackObservation>
             positions (and times) at which modelresult should be extracted
         spatial_method : Optional[str], optional
-            spatial selection/interpolation method, 'nearest', 'contained' (=isel),
-            'inverse_distance' (with 3 nearest points), by default None = 'contained'
+            spatial selection/interpolation method, 'contained' (=isel),
+            'nearest', 'inverse_distance' (with 5 nearest points),
+            by default None = 'inverse_distance'
 
         Returns
         -------
@@ -153,7 +154,7 @@ class DfsuModelResult(SpatialField):
         Note: 'inverse_distance' method uses 5 nearest points and is the default.
         """
 
-        method = spatial_method or "contained"
+        method = spatial_method or "inverse_distance"
         assert method in ["nearest", "contained", "inverse_distance"]
         n_nearest = 5 if method == "inverse_distance" else 1
 

--- a/modelskill/model/dfsu.py
+++ b/modelskill/model/dfsu.py
@@ -98,7 +98,9 @@ class DfsuModelResult(SpatialField):
     def _in_domain(self, x: float, y: float) -> bool:
         return self.data.geometry.contains([x, y])  # type: ignore
 
-    def extract(self, observation: Observation) -> PointModelResult | TrackModelResult:
+    def extract(
+        self, observation: Observation, spatial_interp_method: Optional[str] = None
+    ) -> PointModelResult | TrackModelResult:
         """Extract ModelResult at observation positions
 
         Parameters
@@ -113,17 +115,23 @@ class DfsuModelResult(SpatialField):
         """
         _validate_overlap_in_time(self.time, observation)
         if isinstance(observation, PointObservation):
-            return self.extract_point(observation)
+            return self.extract_point(observation, spatial_interp_method)
         elif isinstance(observation, TrackObservation):
-            return self.extract_track(observation)
+            return self.extract_track(observation, spatial_interp_method)
         else:
             raise NotImplementedError(
                 f"Extraction from {type(self.data)} to {type(observation)} is not implemented."
             )
 
-    def extract_point(self, observation: PointObservation) -> PointModelResult:
+    def extract_point(
+        self, observation: PointObservation, spatial_interp_method: Optional[str] = None
+    ) -> PointModelResult:
         """Spatially extract a PointModelResult from a DfsuModelResult (when data is a Dfsu object),
         given a PointObservation. No time interpolation is done!"""
+        if spatial_interp_method is not None:
+            raise NotImplementedError(
+                "spatial interpolation not implemented for flexible meshes"
+            )
 
         assert isinstance(
             self.data, (mikeio.dfsu.Dfsu2DH, mikeio.DataArray, mikeio.Dataset)
@@ -165,9 +173,15 @@ class DfsuModelResult(SpatialField):
             aux_items=aux_items,
         )
 
-    def extract_track(self, observation: TrackObservation) -> TrackModelResult:
+    def extract_track(
+        self, observation: TrackObservation, spatial_interp_method: Optional[str] = None
+    ) -> TrackModelResult:
         """Extract a TrackModelResult from a DfsuModelResult (when data is a Dfsu object),
         given a TrackObservation."""
+        if spatial_interp_method is not None:
+            raise NotImplementedError(
+                "spatial interpolation not implemented for flexible meshes"
+            )
 
         assert isinstance(
             self.data, (mikeio.dfsu.Dfsu2DH, mikeio.DataArray, mikeio.Dataset)

--- a/modelskill/model/dfsu.py
+++ b/modelskill/model/dfsu.py
@@ -107,6 +107,9 @@ class DfsuModelResult(SpatialField):
         ----------
         observation : <PointObservation> or <TrackObservation>
             positions (and times) at which modelresult should be extracted
+        spatial_interp_method : Optional[str], optional
+            spatial interpolation method, 'nearest', 'contained' (=isel),
+            'inverse_distance' (with 4 nearest points), by default None = 'contained'
 
         Returns
         -------

--- a/modelskill/model/dfsu.py
+++ b/modelskill/model/dfsu.py
@@ -115,15 +115,15 @@ class DfsuModelResult(SpatialField):
         """
         _validate_overlap_in_time(self.time, observation)
         if isinstance(observation, PointObservation):
-            return self.extract_point(observation, spatial_interp_method)
+            return self._extract_point(observation, spatial_interp_method)
         elif isinstance(observation, TrackObservation):
-            return self.extract_track(observation, spatial_interp_method)
+            return self._extract_track(observation, spatial_interp_method)
         else:
             raise NotImplementedError(
                 f"Extraction from {type(self.data)} to {type(observation)} is not implemented."
             )
 
-    def extract_point(
+    def _extract_point(
         self, observation: PointObservation, spatial_interp_method: Optional[str] = None
     ) -> PointModelResult:
         """Spatially extract a PointModelResult from a DfsuModelResult (when data is a Dfsu object),
@@ -173,7 +173,7 @@ class DfsuModelResult(SpatialField):
             aux_items=aux_items,
         )
 
-    def extract_track(
+    def _extract_track(
         self, observation: TrackObservation, spatial_interp_method: Optional[str] = None
     ) -> TrackModelResult:
         """Extract a TrackModelResult from a DfsuModelResult (when data is a Dfsu object),

--- a/modelskill/model/grid.py
+++ b/modelskill/model/grid.py
@@ -112,7 +112,7 @@ class GridModelResult(SpatialField):
     def extract(
         self,
         observation: PointObservation | TrackObservation,
-        spatial_interp_method: Optional[str] = None,
+        spatial_method: Optional[str] = None,
     ) -> PointModelResult | TrackModelResult:
         """Extract ModelResult at observation positions
 
@@ -122,7 +122,7 @@ class GridModelResult(SpatialField):
         ----------
         observation : <PointObservation> or <TrackObservation>
             positions (and times) at which modelresult should be extracted
-        spatial_interp_method : Optional[str], optional
+        spatial_method : Optional[str], optional
             method in xarray.Dataset.interp, typically either "nearest" or
             "linear", by default None = 'linear'
 
@@ -133,20 +133,20 @@ class GridModelResult(SpatialField):
         """
         _validate_overlap_in_time(self.time, observation)
         if isinstance(observation, PointObservation):
-            return self._extract_point(observation, spatial_interp_method)
+            return self._extract_point(observation, spatial_method)
         elif isinstance(observation, TrackObservation):
-            return self._extract_track(observation, spatial_interp_method)
+            return self._extract_track(observation, spatial_method)
         else:
             raise NotImplementedError(
                 f"Extraction from {type(self.data)} to {type(observation)} is not implemented."
             )
 
     def _extract_point(
-        self, observation: PointObservation, spatial_interp_method: Optional[str] = None
+        self, observation: PointObservation, spatial_method: Optional[str] = None
     ) -> PointModelResult:
         """Spatially extract a PointModelResult from a GridModelResult (when data is a xarray.Dataset),
         given a PointObservation. No time interpolation is done!"""
-        method: str = spatial_interp_method or "linear"
+        method: str = spatial_method or "linear"
 
         x, y = observation.x, observation.y
         if (x is None) or (y is None):
@@ -168,7 +168,7 @@ class GridModelResult(SpatialField):
         df = ds.to_dataframe().drop(columns=["x", "y"]).dropna()
         if len(df) == 0:
             raise ValueError(
-                f"Spatial point extraction failed for PointObservation '{observation.name}' in GridModelResult '{self.name}'! (is point outside model domain? Consider spatial_interp_method='nearest')"
+                f"Spatial point extraction failed for PointObservation '{observation.name}' in GridModelResult '{self.name}'! (is point outside model domain? Consider spatial_method='nearest')"
             )
         df = df.rename(columns={self.sel_items.values: self.name})
 
@@ -183,11 +183,11 @@ class GridModelResult(SpatialField):
         )
 
     def _extract_track(
-        self, observation: TrackObservation, spatial_interp_method: Optional[str] = None
+        self, observation: TrackObservation, spatial_method: Optional[str] = None
     ) -> TrackModelResult:
         """Extract a TrackModelResult from a GridModelResult (when data is a xarray.Dataset),
         given a TrackObservation."""
-        method: str = spatial_interp_method or "linear"
+        method: str = spatial_method or "linear"
 
         obs_df = observation.data.to_dataframe()
 

--- a/modelskill/model/grid.py
+++ b/modelskill/model/grid.py
@@ -123,7 +123,8 @@ class GridModelResult(SpatialField):
         observation : <PointObservation> or <TrackObservation>
             positions (and times) at which modelresult should be extracted
         spatial_interp_method : Optional[str], optional
-            method in xarray.Dataset.interp, by default None = 'linear'
+            method in xarray.Dataset.interp, typically either "nearest" or
+            "linear", by default None = 'linear'
 
         Returns
         -------
@@ -145,7 +146,7 @@ class GridModelResult(SpatialField):
     ) -> PointModelResult:
         """Spatially extract a PointModelResult from a GridModelResult (when data is a xarray.Dataset),
         given a PointObservation. No time interpolation is done!"""
-        method: str = spatial_interp_method or "nearest"
+        method: str = spatial_interp_method or "linear"
 
         x, y = observation.x, observation.y
         if (x is None) or (y is None):

--- a/modelskill/model/grid.py
+++ b/modelskill/model/grid.py
@@ -128,15 +128,15 @@ class GridModelResult(SpatialField):
         """
         _validate_overlap_in_time(self.time, observation)
         if isinstance(observation, PointObservation):
-            return self.extract_point(observation, spatial_interp_method)
+            return self._extract_point(observation, spatial_interp_method)
         elif isinstance(observation, TrackObservation):
-            return self.extract_track(observation, spatial_interp_method)
+            return self._extract_track(observation, spatial_interp_method)
         else:
             raise NotImplementedError(
                 f"Extraction from {type(self.data)} to {type(observation)} is not implemented."
             )
 
-    def extract_point(
+    def _extract_point(
         self, observation: PointObservation, spatial_interp_method: Optional[str] = None
     ) -> PointModelResult:
         """Spatially extract a PointModelResult from a GridModelResult (when data is a xarray.Dataset),
@@ -172,7 +172,7 @@ class GridModelResult(SpatialField):
             aux_items=self.sel_items.aux,
         )
 
-    def extract_track(
+    def _extract_track(
         self, observation: TrackObservation, spatial_interp_method: Optional[str] = None
     ) -> TrackModelResult:
         """Extract a TrackModelResult from a GridModelResult (when data is a xarray.Dataset),

--- a/modelskill/model/grid.py
+++ b/modelskill/model/grid.py
@@ -141,7 +141,7 @@ class GridModelResult(SpatialField):
     ) -> PointModelResult:
         """Spatially extract a PointModelResult from a GridModelResult (when data is a xarray.Dataset),
         given a PointObservation. No time interpolation is done!"""
-        spatial_interp_method = spatial_interp_method or "nearest"
+        method: str = spatial_interp_method or "nearest"
 
         x, y = observation.x, observation.y
         if (x is None) or (y is None):
@@ -158,7 +158,7 @@ class GridModelResult(SpatialField):
         assert isinstance(self.data, xr.Dataset)
 
         # TODO: avoid runtrip to pandas if possible (potential loss of metadata)
-        da = self.data.interp(coords=dict(x=x, y=y), method=spatial_interp_method)
+        da = self.data.interp(coords=dict(x=x, y=y), method=method, assume_sorted=True)  # type: ignore
         df = da.to_dataframe().drop(columns=["x", "y"])
         df = df.rename(columns={self.sel_items.values: self.name})
 
@@ -177,7 +177,7 @@ class GridModelResult(SpatialField):
     ) -> TrackModelResult:
         """Extract a TrackModelResult from a GridModelResult (when data is a xarray.Dataset),
         given a TrackObservation."""
-        spatial_interp_method = spatial_interp_method or "linear"
+        method: str = spatial_interp_method or "linear"
 
         obs_df = observation.data.to_dataframe()
 
@@ -188,7 +188,9 @@ class GridModelResult(SpatialField):
 
         assert isinstance(self.data, xr.Dataset)
         da = self.data.interp(
-            coords=dict(time=t, x=x, y=y), method=spatial_interp_method
+            coords=dict(time=t, x=x, y=y),
+            method=method,  # type: ignore
+            assume_sorted=True,
         )
         df = da.to_dataframe().drop(columns=["time"])
         df = df.rename(columns={self.sel_items.values: self.name})

--- a/modelskill/model/grid.py
+++ b/modelskill/model/grid.py
@@ -116,6 +116,8 @@ class GridModelResult(SpatialField):
     ) -> PointModelResult | TrackModelResult:
         """Extract ModelResult at observation positions
 
+        Note: this method is typically not called directly, but through the match() method.
+
         Parameters
         ----------
         observation : <PointObservation> or <TrackObservation>

--- a/modelskill/model/grid.py
+++ b/modelskill/model/grid.py
@@ -158,7 +158,7 @@ class GridModelResult(SpatialField):
         assert isinstance(self.data, xr.Dataset)
 
         # TODO: avoid runtrip to pandas if possible (potential loss of metadata)
-        da = self.data.interp(coords=dict(x=x, y=y), method=method, assume_sorted=True)  # type: ignore
+        da = self.data.interp(coords=dict(x=x, y=y), method=method)  # type: ignore
         df = da.to_dataframe().drop(columns=["x", "y"])
         df = df.rename(columns={self.sel_items.values: self.name})
 
@@ -190,7 +190,6 @@ class GridModelResult(SpatialField):
         da = self.data.interp(
             coords=dict(time=t, x=x, y=y),
             method=method,  # type: ignore
-            assume_sorted=True,
         )
         df = da.to_dataframe().drop(columns=["time"])
         df = df.rename(columns={self.sel_items.values: self.name})

--- a/modelskill/model/grid.py
+++ b/modelskill/model/grid.py
@@ -120,6 +120,8 @@ class GridModelResult(SpatialField):
         ----------
         observation : <PointObservation> or <TrackObservation>
             positions (and times) at which modelresult should be extracted
+        spatial_interp_method : Optional[str], optional
+            method in xarray.Dataset.interp, by default None = 'linear'
 
         Returns
         -------

--- a/modelskill/model/point.py
+++ b/modelskill/model/point.py
@@ -62,11 +62,11 @@ class PointModelResult(TimeSeries):
         super().__init__(data=data)
 
     def extract(
-        self, obs: PointObservation, spatial_interp_method: Optional[str] = None
+        self, obs: PointObservation, spatial_method: Optional[str] = None
     ) -> PointModelResult:
         if not isinstance(obs, PointObservation):
             raise ValueError(f"obs must be a PointObservation not {type(obs)}")
-        if spatial_interp_method is not None:
+        if spatial_method is not None:
             raise NotImplementedError(
                 "spatial interpolation not possible when matching point model results with point observations"
             )

--- a/modelskill/model/point.py
+++ b/modelskill/model/point.py
@@ -61,9 +61,15 @@ class PointModelResult(TimeSeries):
         data[data_var].attrs["kind"] = "model"
         super().__init__(data=data)
 
-    def extract(self, obs: PointObservation) -> PointModelResult:
+    def extract(
+        self, obs: PointObservation, spatial_interp_method: Optional[str] = None
+    ) -> PointModelResult:
         if not isinstance(obs, PointObservation):
             raise ValueError(f"obs must be a PointObservation not {type(obs)}")
+        if spatial_interp_method is not None:
+            raise NotImplementedError(
+                "spatial interpolation not possible when matching point model results with point observations"
+            )
         # TODO check x,y,z
         return self
 

--- a/modelskill/model/track.py
+++ b/modelskill/model/track.py
@@ -68,11 +68,11 @@ class TrackModelResult(TimeSeries):
         super().__init__(data=data)
 
     def extract(
-        self, obs: TrackObservation, spatial_interp_method: Optional[str] = None
+        self, obs: TrackObservation, spatial_method: Optional[str] = None
     ) -> TrackModelResult:
         if not isinstance(obs, TrackObservation):
             raise ValueError(f"obs must be a TrackObservation not {type(obs)}")
-        if spatial_interp_method is not None:
+        if spatial_method is not None:
             raise NotImplementedError(
                 "spatial interpolation not possible when matching track model results with track observations"
             )

--- a/modelskill/model/track.py
+++ b/modelskill/model/track.py
@@ -67,8 +67,14 @@ class TrackModelResult(TimeSeries):
         data[data_var].attrs["kind"] = "model"
         super().__init__(data=data)
 
-    def extract(self, obs: TrackObservation) -> TrackModelResult:
+    def extract(
+        self, obs: TrackObservation, spatial_interp_method: Optional[str] = None
+    ) -> TrackModelResult:
         if not isinstance(obs, TrackObservation):
             raise ValueError(f"obs must be a TrackObservation not {type(obs)}")
+        if spatial_interp_method is not None:
+            raise NotImplementedError(
+                "spatial interpolation not possible when matching track model results with track observations"
+            )
         # TODO check x,y,z
         return self

--- a/notebooks/Gridded_NetCDF_ModelResult.ipynb
+++ b/notebooks/Gridded_NetCDF_ModelResult.ipynb
@@ -1473,7 +1473,7 @@
                 }
             ],
             "source": [
-                "mrERA5.extract(o1).data.head()"
+                "mrERA5.extract(o1, spatial_interp_method=\"nearest\").data.head()"
             ]
         },
         {

--- a/notebooks/Gridded_NetCDF_ModelResult.ipynb
+++ b/notebooks/Gridded_NetCDF_ModelResult.ipynb
@@ -1991,7 +1991,13 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "cc = ms.match(obs=[o1,o2,o3], mod=[mrERA5, mrCMEMS, mrMIKE])"
+                "# o1 is slightly outside the model domain of mrERA5, \n",
+                "# we therefore use \"nearest\" instead of the default spatial interpolation method  \n",
+                "cc = ms.match(\n",
+                "    obs=[o1, o2, o3], \n",
+                "    mod=[mrERA5, mrCMEMS, mrMIKE], \n",
+                "    spatial_interp_method='nearest',\n",
+                ")"
             ]
         },
         {

--- a/notebooks/Gridded_NetCDF_ModelResult.ipynb
+++ b/notebooks/Gridded_NetCDF_ModelResult.ipynb
@@ -1473,7 +1473,7 @@
                 }
             ],
             "source": [
-                "mrERA5.extract(o1, spatial_interp_method=\"nearest\").data.head()"
+                "mrERA5.extract(o1, spatial_method=\"nearest\").data.head()"
             ]
         },
         {
@@ -1996,7 +1996,7 @@
                 "cc = ms.match(\n",
                 "    obs=[o1, o2, o3], \n",
                 "    mod=[mrERA5, mrCMEMS, mrMIKE], \n",
-                "    spatial_interp_method='nearest',\n",
+                "    spatial_method='nearest',\n",
                 ")"
             ]
         },

--- a/tests/model/test_grid.py
+++ b/tests/model/test_grid.py
@@ -144,14 +144,18 @@ def test_grid_aux_items_fail(ERA5_DutchCoast_nc):
 
 def test_grid_extract_point(mr_ERA5_swh, pointobs_epl_hm0):
     pmr = mr_ERA5_swh.extract(pointobs_epl_hm0)
-    ds = pmr.data
 
     assert isinstance(pmr, ms.PointModelResult)
     assert pmr.time[0] == datetime(2017, 10, 27, 0, 0, 0)
     assert pmr.time[-1] == datetime(2017, 10, 29, 18, 0, 0)
     assert pmr.n_points == 67
-    assert len(ds.data_vars) == 1
-    assert pytest.approx(ds.to_pandas().iloc[0, 0]) == 0.875528
+    assert len(pmr.data.data_vars) == 1
+    assert pytest.approx(pmr.data.to_pandas().iloc[0, 0]) == 0.847677
+
+    # default spatial_interp_method='linear'
+    pmr2 = mr_ERA5_swh.extract(pointobs_epl_hm0, spatial_interp_method="nearest")
+    assert pmr2.n_points == 67
+    assert pytest.approx(pmr2.data.to_pandas().iloc[0, 0]) == 0.875528
 
 
 def test_grid_extract_point_xoutside(mr_ERA5_pp1d, pointobs_epl_hm0):

--- a/tests/model/test_grid.py
+++ b/tests/model/test_grid.py
@@ -152,8 +152,8 @@ def test_grid_extract_point(mr_ERA5_swh, pointobs_epl_hm0):
     assert len(pmr.data.data_vars) == 1
     assert pytest.approx(pmr.data.to_pandas().iloc[0, 0]) == 0.847677
 
-    # default spatial_interp_method='linear'
-    pmr2 = mr_ERA5_swh.extract(pointobs_epl_hm0, spatial_interp_method="nearest")
+    # default spatial_method='linear'
+    pmr2 = mr_ERA5_swh.extract(pointobs_epl_hm0, spatial_method="nearest")
     assert pmr2.n_points == 67
     assert pytest.approx(pmr2.data.to_pandas().iloc[0, 0]) == 0.875528
 

--- a/tests/test_aggregated_skill.py
+++ b/tests/test_aggregated_skill.py
@@ -76,7 +76,7 @@ def cc2(o1, o2, o3):
     mr1 = ms.model_result(fn, item=0, name="SW_1")
     fn = "tests/testdata/SW/HKZN_local_2017_DutchCoast_v2.dfsu"
     mr2 = ms.model_result(fn, item=0, name="SW_2")
-    return ms.match([o1, o2, o3], [mr1, mr2])
+    return ms.match([o1, o2, o3], [mr1, mr2], spatial_method="nearest")
 
 
 def test_skill_table(sk_df1):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,4 +59,5 @@ def test_comparison_from_yml():
     assert cc["Klagshamn"].quantity.name == "Water Level"
     assert cc["Drogden"].quantity.name == "Water Level"
 
-    assert cc.score()["HD"] == pytest.approx(0.23287298772)
+    assert cc.score()["HD"] == pytest.approx(0.2331039)
+    # spatial interp nearest: 0.23287298772

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -531,9 +531,8 @@ def test_compare_model_vs_dummy_for_track(mr1, o3):
 
     cmp2 = ms.match(obs=o3, mod=[mr1, mr])
 
-    assert cmp2.score()["dummy"] == pytest.approx(
-        1.225945
-    )  # not identical to above since it is evaluated on a subset of the data
-    assert cmp2.score()["SW_1"] == pytest.approx(
-        0.35179650395619716
-    )  # better than dummy 🙂
+    # not identical to above since it is evaluated on a subset of the data
+    assert cmp2.score()["dummy"] == pytest.approx(1.225945)  
+    
+    # better than dummy 🙂
+    assert cmp2.score()["SW_1"] == pytest.approx(0.3524703)  

--- a/tests/test_multimodelcompare.py
+++ b/tests/test_multimodelcompare.py
@@ -40,7 +40,7 @@ def o3():
 
 @pytest.fixture
 def cc(mr1, mr2, o1, o2, o3):
-    return ms.match([o1, o2, o3], [mr1, mr2])
+    return ms.match([o1, o2, o3], [mr1, mr2], spatial_method="nearest")
 
 
 def test_compare(mr1, mr2, o1, o2, o3):

--- a/tests/test_multivariable_compare.py
+++ b/tests/test_multivariable_compare.py
@@ -89,10 +89,10 @@ def test_mv_skill(cc_1model):
     assert list(df.reset_index().observation) == cc_1model.obs_names
     assert df.index.names[0] == "observation"
     assert df.index.names[1] == "quantity"
-    assert pytest.approx(df.iloc[1].rmse) == 0.22359663
+    assert pytest.approx(df.iloc[1].rmse) == 0.22792652  
     idx = ("HKNA_wind", "Wind speed")
-    assert pytest.approx(df.loc[idx].rmse) == 1.27617894455
-
+    assert pytest.approx(df.loc[idx].rmse) == 1.5610323  
+    # spatial_interp nearest: 0.22359663 and 1.2761789
 
 def test_mv_mm_skill(cc):
     df = cc.skill().to_dataframe()
@@ -100,20 +100,22 @@ def test_mv_mm_skill(cc):
     assert df.index.names[1] == "observation"
     assert df.index.names[2] == "quantity"
     idx = ("SW_1", "HKNA_wind", "Wind speed")
-    assert pytest.approx(df.loc[idx].rmse) == 1.27617894455
+    assert pytest.approx(df.loc[idx].rmse) == 1.5610323
+    # spatial_interp nearest: 1.27617894455
 
     df = cc.sel(model="SW_1").skill().to_dataframe()
     assert df.index.names[0] == "observation"
     assert df.index.names[1] == "quantity"
-    assert pytest.approx(df.iloc[1].rmse) == 0.22359663
+    assert pytest.approx(df.iloc[1].rmse) == 0.2279265
+    # spatial interp nearest: 0.22359663
     idx = ("HKNA_wind", "Wind speed")
-    assert pytest.approx(df.loc[idx].rmse) == 1.27617894455
+    assert pytest.approx(df.loc[idx].rmse) == 1.5610323
 
     df = cc.sel(quantity="Wind speed").skill().to_dataframe()
     assert df.index.names[0] == "model"
     assert df.index.names[1] == "observation"
     idx = ("SW_1", "HKNA_wind")
-    assert pytest.approx(df.loc[idx].rmse) == 1.27617894455
+    assert pytest.approx(df.loc[idx].rmse) == 1.5610323
 
 
 def test_mv_mm_mean_skill(cc):
@@ -121,11 +123,11 @@ def test_mv_mm_mean_skill(cc):
     assert df.index.names[0] == "model"
     assert df.index.names[1] == "quantity"
     idx = ("SW_1", "Wind speed")
-    assert pytest.approx(df.loc[idx].r2) == 0.6392425
+    assert pytest.approx(df.loc[idx].r2) == 0.6246696
     # spatial_interp nearest: 0.63344531
 
     df = cc.sel(quantity="Significant wave height").mean_skill().to_dataframe()
-    assert pytest.approx(df.loc["SW_1"].cc) == 0.9638679
+    assert pytest.approx(df.loc["SW_1"].cc) == 0.9627803
     # spatial_interp nearest: 0.963095
 
 

--- a/tests/test_multivariable_compare.py
+++ b/tests/test_multivariable_compare.py
@@ -121,10 +121,12 @@ def test_mv_mm_mean_skill(cc):
     assert df.index.names[0] == "model"
     assert df.index.names[1] == "quantity"
     idx = ("SW_1", "Wind speed")
-    assert pytest.approx(df.loc[idx].r2) == 0.63344531
+    assert pytest.approx(df.loc[idx].r2) == 0.6392425
+    # spatial_interp nearest: 0.63344531
 
     df = cc.sel(quantity="Significant wave height").mean_skill().to_dataframe()
-    assert pytest.approx(df.loc["SW_1"].cc) == 0.963095
+    assert pytest.approx(df.loc["SW_1"].cc) == 0.9638679
+    # spatial_interp nearest: 0.963095
 
 
 def test_mv_mm_scatter(cc):

--- a/tests/test_pointcompare.py
+++ b/tests/test_pointcompare.py
@@ -107,9 +107,9 @@ def test_score(modelresult_oresund_WL, klagshamn, drogden):
 
     assert cc.score(metric=root_mean_squared_error)[
         "Oresund2D_subset"
-    ] == pytest.approx(0.1986296276629835)
+    ] == pytest.approx(0.19870695)
     sk = cc.skill(metrics=[root_mean_squared_error, mean_absolute_error])
-    sk.root_mean_squared_error.data.mean() == pytest.approx(0.1986296276629835)
+    sk.root_mean_squared_error.data.mean() == pytest.approx(0.19870695)
 
 
 def test_weighted_score(modelresult_oresund_WL):
@@ -132,9 +132,9 @@ def test_weighted_score(modelresult_oresund_WL):
 
     mr = ms.model_result("tests/testdata/Oresund2D_subset.dfsu", item=0, name="Oresund")
 
-    cc = ms.match(obs=[o1, o2], mod=mr)
+    cc = ms.match(obs=[o1, o2], mod=mr, spatial_method="contained")
     unweighted = cc.score()
-    assert unweighted["Oresund"] == pytest.approx(0.1986296276629835)
+    assert unweighted["Oresund"] == pytest.approx(0.1986296)
 
     # Weighted
 
@@ -158,10 +158,10 @@ def test_weighted_score(modelresult_oresund_WL):
         weight=0.1,
     )
 
-    cc_w = ms.match(obs=[o1_w, o2_w], mod=mr)
+    cc_w = ms.match(obs=[o1_w, o2_w], mod=mr, spatial_method="contained")
     weighted = cc_w.score()
 
-    assert weighted["Oresund"] == pytest.approx(0.1666888485806514)
+    assert weighted["Oresund"] == pytest.approx(0.1666888)
 
 
 def test_weighted_score_from_prematched():
@@ -300,7 +300,7 @@ def test_mod_aux_carried_over(klagshamn):
     mr = ms.model_result(
         "tests/testdata/Oresund2D_subset.dfsu", item=0, aux_items="U velocity"
     )
-    cmp = ms.match(klagshamn, mr)
+    cmp = ms.match(klagshamn, mr, spatial_method="contained")
     assert "U velocity" in cmp.data.data_vars
     assert cmp.data["U velocity"].values[0] == pytest.approx(-0.0360998)
     assert cmp.data["U velocity"].attrs["kind"] == "aux"


### PR DESCRIPTION
Allow user to select spatial interp method when matching. 

Not sure what the new argument should be called 🤔. My first idea was `spatial_interp_method`, but it's long and when the choice is "contained" it doesn't seem like a good name. Maybe `spatial_method` is better? Or `spatial_matching`? 

Choosing good default is not easy. 😬

Before this PR the defaults were:

* Dfsu: nearest point for track; contained for point
* Grid: linear for track; nearest for point. 

We need to clean this up before the release! 

Proposed new spatial interpolation defaults:

* Dfsu: inverse_distance for both point and track (both will be linear in time).
* Grid: linear for both point and track.

Some problems/considerations:

* Dfsu: option "contained" is only supported for point, not track
* Dfsu: in MIKE IO the default n_nearest is 3 for points, 5 for tracks (3 seems to little for quad elements), in this PR the default is so far 5 points, but this is then not the same as you would get by default in MIKE IO which could be confusing
* Grid: on track extraction the same interp method is used in both space and time. This is different than all other extractions, but technically hard to get around. 
* If user is matching several models at the same time and both Dfsu and Grid are present, then it's hard to chose anything else than spatial_interp_method=None, as there are no good options that hold for both Dfsu and Grid. Should we through an error/warning if user tries to set spatial_interp_method in this case? 
