### PR TITLE
Remove binsize argument from gridded_skill

### DIFF
--- a/modelskill/comparison/_collection.py
+++ b/modelskill/comparison/_collection.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import tempfile
 from typing import (
+    Any,
     Callable,
     Dict,
     List,
@@ -617,8 +618,7 @@ class ComparerCollection(Mapping, Scoreable):
 
     def gridded_skill(
         self,
-        bins=5,
-        binsize: float | None = None,
+        bins: Any = 5,
         by: str | Iterable[str] | None = None,
         metrics: Iterable[str] | Iterable[Callable] | str | Callable | None = None,
         n_min: Optional[int] = None,
@@ -632,9 +632,6 @@ class ComparerCollection(Mapping, Scoreable):
             criteria to bin x and y by, argument bins to pd.cut(), default 5
             define different bins for x and y a tuple
             e.g.: bins = 5, bins = (5,[2,3,5])
-        binsize : float, optional
-            bin size for x and y dimension, overwrites bins
-            creates bins with reference to round(mean(x)), round(mean(y))
         by : str, List[str], optional
             group by, by default ["model", "observation"]
 
@@ -676,7 +673,7 @@ class ComparerCollection(Mapping, Scoreable):
             n            (x, y) int32 3 0 0 14 37 17 50 36 72 ... 0 0 15 20 0 0 0 28 76
             bias         (x, y) float64 -0.02626 nan nan ... nan 0.06785 -0.1143
 
-        >>> gs = cc.gridded_skill(binsize=0.5)
+        >>> gs = cc.gridded_skill()
         >>> gs.data.coords
         Coordinates:
             observation   'alti'
@@ -705,7 +702,7 @@ class ComparerCollection(Mapping, Scoreable):
         metrics = _parse_metric(metrics)
 
         df = cmp._to_long_dataframe()
-        df = _add_spatial_grid_to_df(df=df, bins=bins, binsize=binsize)
+        df = _add_spatial_grid_to_df(df=df, bins=bins)
 
         agg_cols = _parse_groupby(by, n_mod=cmp.n_models, n_qnt=cmp.n_quantities)
         if "x" not in agg_cols:
@@ -1123,7 +1120,6 @@ class ComparerCollection(Mapping, Scoreable):
     def spatial_skill(
         self,
         bins=5,
-        binsize=None,
         by=None,
         metrics=None,
         n_min=None,
@@ -1134,7 +1130,6 @@ class ComparerCollection(Mapping, Scoreable):
         )
         return self.gridded_skill(
             bins=bins,
-            binsize=binsize,
             by=by,
             metrics=metrics,
             n_min=n_min,

--- a/modelskill/comparison/_comparison.py
+++ b/modelskill/comparison/_comparison.py
@@ -63,8 +63,7 @@ class Scoreable(Protocol):
 
     def gridded_skill(
         self,
-        bins: int = 5,
-        binsize: float | None = None,
+        bins: Any = ...,
         by: str | Iterable[str] | None = None,
         metrics: Iterable[str] | Iterable[Callable] | str | Callable | None = None,
         n_min: int | None = None,
@@ -1082,7 +1081,6 @@ class Comparer(Scoreable):
     def gridded_skill(
         self,
         bins: int = 5,
-        binsize: float | None = None,
         by: str | Iterable[str] | None = None,
         metrics: Iterable[str] | Iterable[Callable] | str | Callable | None = None,
         n_min: int | None = None,
@@ -1096,9 +1094,6 @@ class Comparer(Scoreable):
             criteria to bin x and y by, argument bins to pd.cut(), default 5
             define different bins for x and y a tuple
             e.g.: bins = 5, bins = (5,[2,3,5])
-        binsize : float, optional
-            bin size for x and y dimension, overwrites bins
-            creates bins with reference to round(mean(x)), round(mean(y))
         by : (str, List[str]), optional
             group by column name or by temporal bin via the freq-argument
             (using pandas pd.Grouper(freq)),
@@ -1135,7 +1130,7 @@ class Comparer(Scoreable):
             n            (x, y) int32 3 0 0 14 37 17 50 36 72 ... 0 0 15 20 0 0 0 28 76
             bias         (x, y) float64 -0.02626 nan nan ... nan 0.06785 -0.1143
 
-        >>> gs = cc.gridded_skill(binsize=0.5)
+        >>> gs = cc.gridded_skill()
         >>> gs.data.coords
         Coordinates:
             observation   'alti'
@@ -1159,7 +1154,7 @@ class Comparer(Scoreable):
             raise ValueError("No data to compare")
 
         df = cmp._to_long_dataframe()
-        df = _add_spatial_grid_to_df(df=df, bins=bins, binsize=binsize)
+        df = _add_spatial_grid_to_df(df=df, bins=bins)
 
         agg_cols = _parse_groupby(by=by, n_mod=cmp.n_models, n_qnt=1)
         if "x" not in agg_cols:
@@ -1310,7 +1305,6 @@ class Comparer(Scoreable):
     def spatial_skill(
         self,
         bins=5,
-        binsize=None,
         by=None,
         metrics=None,
         n_min=None,
@@ -1322,7 +1316,6 @@ class Comparer(Scoreable):
         )
         return self.gridded_skill(
             bins=bins,
-            binsize=binsize,
             by=by,
             metrics=metrics,
             n_min=n_min,

--- a/modelskill/comparison/_utils.py
+++ b/modelskill/comparison/_utils.py
@@ -9,31 +9,14 @@ TimeTypes = Union[str, np.datetime64, pd.Timestamp, datetime]
 IdxOrNameTypes = Union[int, str, List[int], List[str]]
 
 
-def _add_spatial_grid_to_df(
-    df: pd.DataFrame, bins, binsize: Optional[float]
-) -> pd.DataFrame:
-    if binsize is None:
-        # bins from bins
-        if isinstance(bins, tuple):
-            bins_x = bins[0]
-            bins_y = bins[1]
-        else:
-            bins_x = bins
-            bins_y = bins
+def _add_spatial_grid_to_df(df: pd.DataFrame, bins) -> pd.DataFrame:
+    if isinstance(bins, tuple):
+        bins_x = bins[0]
+        bins_y = bins[1]
     else:
-        # bins from binsize
-        x_ptp = df.x.values.ptp()  # type: ignore
-        y_ptp = df.y.values.ptp()  # type: ignore
-        nx = int(np.ceil(x_ptp / binsize))
-        ny = int(np.ceil(y_ptp / binsize))
-        x_mean = np.round(df.x.mean())
-        y_mean = np.round(df.y.mean())
-        bins_x = np.arange(
-            x_mean - nx / 2 * binsize, x_mean + (nx / 2 + 1) * binsize, binsize
-        )
-        bins_y = np.arange(
-            y_mean - ny / 2 * binsize, y_mean + (ny / 2 + 1) * binsize, binsize
-        )
+        bins_x = bins
+        bins_y = bins
+
     # cut and get bin centre
     df["xBin"] = pd.cut(df.x, bins=bins_x)
     df["xBin"] = df["xBin"].apply(lambda x: x.mid)

--- a/tests/test_trackcompare.py
+++ b/tests/test_trackcompare.py
@@ -336,12 +336,6 @@ def test_gridded_skill_bins(comparer):
     assert len(ds.x) == 2
     assert len(ds.y) == 3
 
-    # binsize (overwrites bins)
-    ds = comparer.gridded_skill(metrics=["bias"], binsize=2.5, bins=100)
-    assert len(ds.x) == 4
-    assert len(ds.y) == 3
-    assert ds.x[0] == -0.75
-
 
 # This test doesn't test anything meaningful
 # def test_gridded_skill_by(comparer):


### PR DESCRIPTION
The previous implementation missed parts of the data.

This PR removes this argument.

More explicit control over bins, use the bins argument with a list of bins.
