### PR TITLE
Skillgrid ecdf

### DIFF
--- a/modelskill/skill_grid.py
+++ b/modelskill/skill_grid.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 from typing import Any, Iterable, overload, Hashable, TYPE_CHECKING
 import warnings
+
+import numpy as np
 import xarray as xr
 import matplotlib.pyplot as plt
 
@@ -109,14 +111,12 @@ class SkillGridArray(SkillGridMixin):
         return ax
 
     def ecdf(self) -> Axes:
-        import matplotlib.pyplot as plt
-        import numpy as np
-
+        # TODO ax argument
         fig, ax = plt.subplots()
 
         # TODO fix that self.mod_names is empty
         for model in self.mod_names:
-            all_vals = self.data.sel(model=model).values.flatten()
+            all_vals = self.data.sel(model=model).to_numpy().flatten()
             non_na_vals = all_vals[~np.isnan(all_vals)]
             ax.ecdf(non_na_vals, label=model)
             ax.set_ylabel("CDF")

--- a/modelskill/skill_grid.py
+++ b/modelskill/skill_grid.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Any, Iterable, overload, Hashable, TYPE_CHECKING
 import warnings
 import xarray as xr
+import matplotlib.pyplot as plt
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -105,6 +106,25 @@ class SkillGridArray(SkillGridMixin):
             ax = da.plot(col=extra_dims[0], **kwargs)
         else:
             ax = da.plot(**kwargs)
+        return ax
+
+    def ecdf(self) -> Axes:
+        import matplotlib.pyplot as plt
+        import numpy as np
+
+        fig, ax = plt.subplots()
+
+        # TODO fix that self.mod_names is empty
+        for model in self.mod_names:
+            all_vals = self.data.sel(model=model).values.flatten()
+            non_na_vals = all_vals[~np.isnan(all_vals)]
+            ax.ecdf(non_na_vals, label=model)
+            ax.set_ylabel("CDF")
+            metric = self.data.name
+            ax.set_xlabel(metric)
+
+        plt.legend()
+
         return ax
 
 


### PR DESCRIPTION
Ecdf is a way to compare the skill of two (or more) models across many observation locations, very common in hydrology ([Kratzert _et al_, 2019](https://hess.copernicus.org/articles/23/5089/2019/).

This PR is an attempt to add this functionality to gridded skill.

Example:

`plot()` delegates to `xarray`, so how do I add `plot.ecdf()`🤔 
![image](https://github.com/DHI/modelskill/assets/614215/d4616b56-e2ad-4d15-b326-06acc17e909a)
