### PR TITLE
Prepare for NumPy 2

### DIFF
--- a/modelskill/utils.py
+++ b/modelskill/utils.py
@@ -141,7 +141,7 @@ def make_unique_index(
             "Time axis has duplicate entries. Now adding milliseconds to non-unique entries to make index unique."
         )
     values = df_index.duplicated(keep=False).astype(float)  # keep='first'
-    values[values == 0] = np.NaN
+    values[values == 0] = np.nan
 
     missings = np.isnan(values)
     cumsum = np.cumsum(~missings)


### PR DESCRIPTION
```bash
$ ruff --preview --select NPY201
modelskill/utils.py:144:27: NPY201 [*] `np.NaN` will be removed in NumPy 2.0. Use `numpy.nan` instead.
Found 1 error.
[*] 1 fixable with the `--fix` option.
```
Seems like we are well prepared for this upcoming release.

_The tentative release date for the first release candidate of NumPy 2.0 is around 1 Feb 2024, and the final release 6-8 weeks later._ <https://github.com/numpy/numpy/issues/24300>