### PR TITLE
New Peak Ratio

### DIFF
--- a/modelskill/metrics.py
+++ b/modelskill/metrics.py
@@ -580,19 +580,27 @@ def peak_ratio(
     dt_int_mode = float(stats.mode(dt_int, keepdims=False)[0]) / 1e9  # in seconds
     N_years = dt_int_mode / 24 / 3600 / 365.25 * len(time)
     found_peaks = []
-    for data in [obs, model]:
-        peak_index, AAP_ = _partial_duration_series(
+   
+    peak_index, AAP_ = _partial_duration_series(
             time,
-            data,
+            obs,
             inter_event_level=inter_event_level,
             AAP=AAP,
             inter_event_time=inter_event_time,
         )
-        peaks = data[peak_index]
-        peaks_sorted = peaks.sort_values(ascending=False)
-        found_peaks.append(peaks_sorted)
-    found_peaks_obs = found_peaks[0]
-    found_peaks_mod = found_peaks[1]
+    peaks = obs[peak_index]
+    found_peaks_obs = peaks.sort_values(ascending=False)
+
+    peak_index, _ = _partial_duration_series(
+            time,
+            model,
+            inter_event_level=inter_event_level,
+            AAP=AAP,
+            inter_event_time=inter_event_time,
+        )
+    peaks = model[peak_index]
+    found_peaks_mod = peaks.sort_values(ascending=False)
+
     top_n_peaks = max(1, min(round(AAP_ * N_years), np.sum(peaks)))
     # Resample~ish, find peaks spread maximum Half the inter event time (if inter event =36, select data paired +/- 18h) (or inter_event) and then select
     indices_mod = (

--- a/modelskill/metrics.py
+++ b/modelskill/metrics.py
@@ -578,9 +578,7 @@ def peak_ratio(
     # Calculate number of years
     dt_int = time[1:].values - time[0:-1].values
     dt_int_mode = float(stats.mode(dt_int, keepdims=False)[0]) / 1e9  # in seconds
-    N_years = dt_int_mode / 24 / 3600 / 365.25 * len(time)
-    found_peaks = []
-   
+    N_years = dt_int_mode / 24 / 3600 / 365.25 * len(time)  
     peak_index, AAP_ = _partial_duration_series(
             time,
             obs,

--- a/modelskill/metrics.py
+++ b/modelskill/metrics.py
@@ -557,7 +557,7 @@ def peak_ratio(
     ----------
     inter_event_level (float, optional)
         Inter-event level threshold (default: 0.7).
-    AAP (float, optional)
+    AAP (int or float, optional)
         Average Annual Peaks (ie, Number of peaks per year, on average). (default: 2)
     inter_event_time (str, optional)
             Maximum time interval between peaks (default: 36 hours).

--- a/modelskill/metrics.py
+++ b/modelskill/metrics.py
@@ -532,8 +532,8 @@ def pr(
     obs: pd.Series,
     model: np.ndarray,
     inter_event_level: float = 0.7,
-    AAP: int = 2,
-    inter_event_time="36h",
+    AAP: Union[int, float] = 2,
+    inter_event_time: str ="36h",
 ) -> float:
     """alias for peak_ratio"""
     assert obs.size == model.size
@@ -544,8 +544,8 @@ def peak_ratio(
     obs: pd.Series,
     model: np.ndarray,
     inter_event_level: float = 0.7,
-    AAP: int = 2,
-    inter_event_time="36h",
+    AAP: Union[int, float]  = 2,
+    inter_event_time: str="36h",
 ) -> float:
     r"""Peak Ratio
 

--- a/tests/test_comparercollection.py
+++ b/tests/test_comparercollection.py
@@ -568,7 +568,7 @@ def test_peak_ratio(cc):
 def test_peak_ratio_2(cc_pr):
     sk = cc_pr.skill(metrics=["peak_ratio"])
     assert "peak_ratio" in sk.data.columns
-    assert sk.to_dataframe()["peak_ratio"].values == pytest.approx(1.0799999095653732)
+    assert sk.to_dataframe()["peak_ratio"].values == pytest.approx(0.88999995)
 
 
 def test_copy(cc):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -201,7 +201,7 @@ def test_pr(obs_series: pd.Series, mod_series: pd.Series) -> None:
 
     pr = mtr.pr(obs, mod)
 
-    assert pr == pytest.approx(1.0799999095653732)
+    assert pr == pytest.approx(0.889999947851914)
 
 
 def test_pr_2(obs_series, mod_series):
@@ -212,7 +212,7 @@ def test_pr_2(obs_series, mod_series):
 
     pr = mtr.pr(obs, mod, AAP=8, inter_event_level=0.2)
 
-    assert pr == pytest.approx(1.0949999434255118)
+    assert pr == pytest.approx(0.947499960537655)
 
 
 def test_metric_has_dimension():


### PR DESCRIPTION
Hi.

After a **long** discussion we decided to update the peak selection in the Peak Ratio.
* Before this PullRequest the individual N-largests peaks between model and measurements were selected and then intersected (ie, finding the joint-events only), and the remaining joint-peaks were used in the calculation.
* With this PullRequest , all individual peaks are selected independently (from measurements and model), intersected (finding the joint-events), and then the N-largest peaks are used for the calculation.

Small change but has some implications in the results. Also the number of times the user gets a NaN (no joint events) is much lower now (still can happen with very short time series with no evident peaks).
I had to obviously update the tests results of PR as the expected values now change.


Aligns with what was done here:
https://github.com/DHI/potpy/pull/39