### PR TITLE
Fixing issue with x axis label

### DIFF
--- a/modelskill/skill.py
+++ b/modelskill/skill.py
@@ -103,13 +103,17 @@ class SkillArrayPlotter:
         axes = df.plot.line(**kwargs)
 
         xlabels = list(df.index)
-        nx = len(xlabels)
+        numeric_index = all(isinstance(item, (int, float)) for item in xlabels)
 
         if not isinstance(axes, Iterable):
             axes = [axes]
         for ax in axes:
             if not isinstance(df.index, pd.DatetimeIndex):
-                ax.set_xticks(np.arange(nx))
+                if numeric_index:
+                    xlabel_positions = xlabels
+                else:
+                    xlabel_positions = np.arange(len(xlabels))
+                ax.set_xticks(xlabel_positions)
                 ax.set_xticklabels(xlabels, rotation=90)
         return axes
 

--- a/modelskill/skill.py
+++ b/modelskill/skill.py
@@ -112,7 +112,7 @@ class SkillArrayPlotter:
                 if numeric_index:
                     xlabel_positions = xlabels
                 else:
-                    xlabel_positions = np.arange(len(xlabels))
+                    xlabel_positions = np.arange(len(xlabels)).tolist()
                 ax.set_xticks(xlabel_positions)
                 ax.set_xticklabels(xlabels, rotation=90)
         return axes


### PR DESCRIPTION
Previously, by default, the x positions of the skill plots were at [1, 2, 3, ..., n]. However, when an aux variable is numeric, that raised rendering issues (see issue #429). 

This PR changes the handling of x labels in skill plots based on whether the x values are numeric or not.