### PR TITLE
Fix/Scatter plot density with few points

### DIFF
--- a/modelskill/comparison/_collection_plotter.py
+++ b/modelskill/comparison/_collection_plotter.py
@@ -91,8 +91,9 @@ class ComparerCollectionPlotter:
         show_density: bool, optional
             show the data density as a colormap of the scatter, by default
             None. If both `show_density` and `show_hist` are None, then
-            `show_density` is used by default. For binning the data, the
-            kword `bins=Float` is used.
+            `show_density` is used by default. If number of points is less
+            than 200, then `show_density` is False as default.
+            For binning the data, the kword `bins=Float` is used.
         norm : matplotlib.colors norm
             colormap normalization. If None, defaults to
             matplotlib.colors.PowerNorm(vmin=1, gamma=0.5)

--- a/modelskill/comparison/_comparer_plotter.py
+++ b/modelskill/comparison/_comparer_plotter.py
@@ -518,8 +518,9 @@ class ComparerPlotter:
         show_density: bool, optional
             show the data density as a colormap of the scatter, by default
             None. If both `show_density` and `show_hist` are None, then
-            `show_density` is used by default. For binning the data, the
-            kword `bins=Float` is used.
+            `show_density` is used by default. If number of points is less
+            than 200, then `show_density` is False as default.
+            For binning the data, the kword `bins=Float` is used.
         norm : matplotlib.colors norm
             colormap normalization. If None, defaults to
             matplotlib.colors.PowerNorm(vmin=1, gamma=0.5)

--- a/modelskill/plotting/_scatter.py
+++ b/modelskill/plotting/_scatter.py
@@ -77,8 +77,8 @@ def scatter(
         show the data density as a 2d histogram, by default None
     show_density: bool, optional
         show the data density as a colormap of the scatter, by default None. If both `show_density` and `show_hist`
-        are None, then `show_density` is used by default.
-        for binning the data, the previous kword `bins=Float` is used
+        are None, then `show_density` is used by default. If number of points is less than 200, then `show_density`
+        is False by default. For binning the data, the previous kword `bins=Float` is used
     norm : matplotlib.colors.Normalize
         colormap normalization
         If None, defaults to matplotlib.colors.PowerNorm(vmin=1,gamma=0.5)
@@ -129,10 +129,6 @@ def scatter(
         )
         skill_scores = kwargs.pop("skill_df").to_dict("records")[0]
 
-    if show_hist is None and show_density is None:
-        # Default: points density
-        show_density = True
-
     if len(x) != len(y):
         raise ValueError("x & y are not of equal length")
 
@@ -141,6 +137,12 @@ def scatter(
 
     x_sample, y_sample = sample_points(x, y, show_points)
     xq, yq = quantiles_xy(x, y, quantiles)
+
+    if show_hist is None and show_density is None:
+        # Default: points density
+        show_density = True
+        if len(x_sample) < 200:  # or nbins?
+            show_density = False
 
     xmin, xmax = x.min(), x.max()
     ymin, ymax = y.min(), y.max()


### PR DESCRIPTION
Scatter plot can fail when strange error message if you trying to plot only few points. The problem is the density calculation which anyway does not make sense for few points. The solution in this PR is to change the default behavior of show_density if number of points is less than 200 to False. 

Note that if user manually sets show_density=True or a very high number of bins are used, the same error could still occur. So it would be even better to catch the problem in the code and issue a better error message that could help the user. 