### PR TITLE
Experiment with duckdb for persistence

### DIFF
--- a/modelskill/comparison/_comparison.py
+++ b/modelskill/comparison/_comparison.py
@@ -1259,13 +1259,16 @@ class Comparer(Scoreable):
         """
         ext = Path(filename).suffix
 
-        match ext:
-            case ".db":
-                self._save_to_duckdb(filename, name)
-            case ".nc":
-                self._save_to_netcdf(filename)
-            case _:
-                raise NotImplementedError(f"Unknown extension: {ext}")
+        # match ext:
+        #    case ".db":
+        if ext == ".db":
+            self._save_to_duckdb(filename, name)
+        elif ext == ".nc":
+            #    case ".nc":
+            self._save_to_netcdf(filename)
+        else:
+            #    case _:
+            raise NotImplementedError(f"Unknown extension: {ext}")
 
     def _save_to_netcdf(self, filename) -> None:
         ds = self.data
@@ -1353,13 +1356,16 @@ class Comparer(Scoreable):
         # get extension
         ext = Path(filename).suffix
 
-        match ext:
-            case ".db":
-                return Comparer._load_from_duckdb(filename, name)
-            case ".nc":
-                return Comparer._load_from_netcdf(filename)
-            case _:
-                raise NotImplementedError(f"Unknown extension: {ext}")
+        # match ext:
+        #    case ".db":
+        if ext == ".db":
+            return Comparer._load_from_duckdb(filename, name)
+        elif ext == ".nc":
+            #    case ".nc":
+            return Comparer._load_from_netcdf(filename)
+        else:
+            #    case _:
+            raise NotImplementedError(f"Unknown extension: {ext}")
 
     @staticmethod
     def _load_from_duckdb(filename, name: Optional[str]) -> "Comparer":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ ignore = ["E501"]
 select = ["E4", "E7", "E9", "F", "D200", "D205"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.9"
 ignore_missing_imports = true
 warn_unreachable = false
 no_implicit_optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ ignore = ["E501"]
 select = ["E4", "E7", "E9", "F", "D200", "D205"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 ignore_missing_imports = true
 warn_unreachable = false
 no_implicit_optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "netCDF4",
     "scipy",
     "jinja2",
+    "duckdb>=1.1.3",
 ]
 
 authors = [

--- a/tests/test_comparer.py
+++ b/tests/test_comparer.py
@@ -962,3 +962,10 @@ def test_save_load(pc, tmp_path) -> None:
     assert "m1" in pc2.mod_names
     assert "m2" in pc2.mod_names
     assert pc2.n_points == 5
+    assert pc2.data.m1.attrs["kind"] == "model"
+    assert pc2.data.m2.attrs["kind"] == "model"
+    assert pc2.data.Observation.attrs["kind"] == "observation"
+
+    # TODO global attrs
+
+    # TODO raw_mod_data

--- a/tests/test_comparer.py
+++ b/tests/test_comparer.py
@@ -951,3 +951,14 @@ def test_from_matched_non_scalar_xy_fails():
             x=df.lon,
             y=df.lat,
         )
+
+
+def test_save_load(pc, tmp_path) -> None:
+    fp = tmp_path / "test.db"
+
+    pc.save(fp)
+    pc2 = Comparer.load(fp)
+
+    assert "m1" in pc2.mod_names
+    assert "m2" in pc2.mod_names
+    assert pc2.n_points == 5

--- a/tests/test_comparer.py
+++ b/tests/test_comparer.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 from modelskill.comparison import Comparer
 from modelskill import __version__
 import modelskill as ms
+from modelskill.model.point import PointModelResult
 
 
 @pytest.fixture
@@ -966,6 +967,7 @@ def test_save_load(pc, tmp_path) -> None:
     assert pc2.data.m2.attrs["kind"] == "model"
     assert pc2.data.Observation.attrs["kind"] == "observation"
 
-    # TODO global attrs
-
-    # TODO raw_mod_data
+    assert pc2.name == "fake point obs"
+    assert pc2.gtype == "point"
+    assert len(pc2.raw_mod_data["m1"]) == 6
+    assert isinstance(pc2.raw_mod_data["m2"], PointModelResult)

--- a/tests/test_comparercollection.py
+++ b/tests/test_comparercollection.py
@@ -412,7 +412,8 @@ def test_save_and_load_preserves_order_of_comparers(tmp_path):
     assert cc[1].name == "alpha"
     assert cc[2].name == "bravo"
 
-    fn = tmp_path / "test_cc.msk"
+    # fn = tmp_path / "test_cc.msk"
+    fn = tmp_path / "test_cc.db"
     cc.save(fn)
 
     cc2 = modelskill.load(fn)
@@ -422,7 +423,7 @@ def test_save_and_load_preserves_order_of_comparers(tmp_path):
 
 
 def test_save(cc: modelskill.ComparerCollection, tmp_path):
-    fn = tmp_path / "test_cc.msk"
+    fn = tmp_path / "test_cc.db"
     assert cc[0].data.attrs["modelskill_version"] == modelskill.__version__
     cc.save(fn)
 
@@ -434,7 +435,8 @@ def test_save(cc: modelskill.ComparerCollection, tmp_path):
 
 
 def test_load_from_root_module(cc, tmp_path):
-    fn = tmp_path / "test_cc.msk"
+    # fn = tmp_path / "test_cc.msk"
+    fn = tmp_path / "test_cc.db"
     cc.save(fn)
 
     cc2 = modelskill.load(fn)
@@ -442,7 +444,8 @@ def test_load_from_root_module(cc, tmp_path):
 
 
 def test_save_and_load_preserves_raw_model_data(cc, tmp_path):
-    fn = tmp_path / "test_cc.msk"
+    # fn = tmp_path / "test_cc.msk"
+    fn = tmp_path / "test_cc.db"
     assert len(cc["fake point obs"].raw_mod_data["m1"]) == 6
     cc.save(fn)
 

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -393,10 +393,13 @@ def test_save_comparercollection(o1, o3, tmp_path):
 
     cc = ms.match([o1, o3], da)
 
-    fn = tmp_path / "cc.msk"
+    # fn = tmp_path / "cc.msk"
+    fn = tmp_path / "cc.db"
     cc.save(fn)
 
     assert fn.exists()
+
+    # TODO check that we can load it again and that it is the same
 
 
 def test_wind_directions():


### PR DESCRIPTION
Experiment with storing the matched data of a `Comparer` in a duckdb file.

Pretty straightforward to inspect:
```
>>> import duckdb
>>> con = duckdb.connect("test.db")
>>> con.sql("SHOW TABLES")
┌─────────┐
│  name   │
│ varchar │
├─────────┤
│ data    │
└─────────┘

>>> con.sql("Select * from data")
┌─────────────────────┬─────────────┬────────┬────────┐
│        time         │ Observation │   m1   │   m2   │
│    timestamp_ns     │   double    │ double │ double │
├─────────────────────┼─────────────┼────────┼────────┤
│ 2019-01-01 00:00:00 │         1.0 │    1.5 │    1.1 │
│ 2019-01-02 00:00:00 │         2.0 │    2.4 │    2.2 │
│ 2019-01-03 00:00:00 │         3.0 │    3.6 │    3.1 │
│ 2019-01-04 00:00:00 │         4.0 │    4.9 │    4.2 │
│ 2019-01-05 00:00:00 │         5.0 │    5.6 │    4.9 │
└─────────────────────┴─────────────┴────────┴────────┘
```