### PR TITLE
pr bug fix

### DIFF
--- a/modelskill/metrics.py
+++ b/modelskill/metrics.py
@@ -611,7 +611,7 @@ def peak_ratio(
     peaks = model[peak_index]
     found_peaks_mod = peaks.sort_values(ascending=False)
 
-    top_n_peaks = max(1, min(round(AAP_ * N_years), np.sum(peaks)))
+    top_n_peaks = max(1, min(round(AAP_ * N_years), len(peaks)))
     # Resample~ish, find peaks spread maximum Half the inter event time (if inter event =36, select data paired +/- 18h) (or inter_event) and then select
     indices_mod = (
         abs(found_peaks_obs.index.values[:, None] - found_peaks_mod.index.values)


### PR DESCRIPTION
I found a bug in the Peak Ratio, so rare that almost never shows up, but in case where the peaks are VERY small (as in, <<1) it could show up.

The top N peaks must be selected as the `minimum` between the `Average Annual  Peaks` * `Number of years` (so eg in 40 years with AAP 2  = 80 peaks) and the total number of peaks (`len(peaks)`)

I was doing a `np.sum(peaks)` of the peaks, ie, adding the Peak Values.
This is clearly wrong. I should either have done `np.sum(peak_index)` since `peak index` is an array of booleans , or simply, just count the total number of peaks (`len(peaks)`), as was done in this PR