### PR TITLE
Support DummyModel in multimodel comparison

### DIFF
--- a/src/modelskill/matching.py
+++ b/src/modelskill/matching.py
@@ -267,7 +267,10 @@ def match(
         )
 
     if len(obs) > 1 and isinstance(mod, Collection) and len(mod) > 1:
-        if not all(isinstance(m, (DfsuModelResult, GridModelResult)) for m in mod):
+        if not all(
+            isinstance(m, (DfsuModelResult, GridModelResult, DummyModelResult))
+            for m in mod
+        ):
             raise ValueError(
                 """
                 In case of multiple observations, multiple models can _only_ 

--- a/tests/test_multimodelcompare.py
+++ b/tests/test_multimodelcompare.py
@@ -386,3 +386,9 @@ def test_mm_plot_timeseries(cc):
     assert "EPL" in ax.get_title()
 
     plt.close("all")
+
+
+def test_match_including_dummy(mr1, mr2, o1, o2, o3):
+    mr3 = ms.DummyModelResult(strategy="constant", data=0.0)
+    cc = ms.match([o1, o2, o3], [mr3, mr1, mr2])
+    assert "dummy" in cc.mod_names


### PR DESCRIPTION
It is now possible to include a `DummyModelResult` in a multi-observation comparison.

<img width="843" height="473" alt="image" src="https://github.com/user-attachments/assets/756c425b-d333-4d10-922b-02bc019e4af1" />

But with the current implementation, the mean strategy calculates the mean of the observation, before cropping to a common period, thus bias will not automatically be 0.
<img width="874" height="426" alt="image" src="https://github.com/user-attachments/assets/d457e61c-194a-4705-970b-23b6be9d6c5d" />
