### PR TITLE
Add CI workflow to test against mikeio main branch

### DIFF
--- a/.github/workflows/test_mikeio_main.yml
+++ b/.github/workflows/test_mikeio_main.yml
@@ -8,11 +8,6 @@ on:
     # Run weekly on Mondays at 5:00 AM UTC
     - cron: '0 5 * * 1'
 
-  pull_request:
-    branches: [main]
-    paths:
-      - '.github/workflows/test_mikeio_main.yml'
-
 jobs:
   test-mikeio-main:
     runs-on: ubuntu-latest
@@ -31,25 +26,7 @@ jobs:
 
       - name: Install mikeio from main branch
         run: |
-          uv pip install git+https://github.com/DHI/mikeio.git@main
+          uv add "git+https://github.com/DHI/mikeio.git@main"
 
       - name: Test
-        run: |
-          # Run tests with warnings enabled and capture output
-          pytest -W default 2>&1 | tee test_output.txt || true
-
-          # Highlight mikeio-related warnings
-          echo "## Checking for mikeio warnings..."
-          if grep -i "warning.*mikeio\|mikeio.*warning\|deprecat" test_output.txt; then
-            echo "::warning::Found mikeio-related warnings - review output above"
-          fi
-
-          # Check if tests actually failed
-          if ! make test; then
-            exit 1
-          fi
-
-      - name: Report status
-        if: failure()
-        run: |
-          echo "::warning::Tests failed against mikeio main branch. This may indicate upcoming compatibility issues."
+        run: make test


### PR DESCRIPTION
Adds a new GitHub Actions workflow that tests ModelSkill against the development version of mikeio to catch breaking changes early.

Replaces similar functionality in the mikeio repo <https://github.com/DHI/mikeio/blob/main/.github/workflows/downstream_test.yml>

