### PR TITLE
Make netCDF4 an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Or the development version:
 
 `> pip install https://github.com/DHI/modelskill/archive/main.zip`
 
+### Optional dependencies
+
+For saving/loading `Comparer` objects to NetCDF format:
+
+`> pip install modelskill[netcdf]`
+
 
 ## Example notebooks
 

--- a/docs/user-guide/getting-started.qmd
+++ b/docs/user-guide/getting-started.qmd
@@ -27,6 +27,24 @@ uv pip install modelskill
 ```
 :::
 
+### Optional dependencies
+
+For saving/loading `Comparer` objects to NetCDF format, install the `netcdf` extra:
+
+::: {.panel-tabset}
+## pip
+
+```bash
+pip install modelskill[netcdf]
+```
+
+## uv
+
+```bash
+uv pip install modelskill[netcdf]
+```
+:::
+
 ## Skill assessment
 
 The simplest use-case for skill assessment is when you have a dataset of matched model results and observations in tabular format.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "mikeio >= 1.2",
     "matplotlib",
     "xarray",
-    "netCDF4",
     "scipy",
     "jinja2", # used for skill.style
 ]
@@ -48,7 +47,6 @@ dev = [
     "ruff==0.6.2",
     "quarto-cli==1.5.57",
     "quartodoc==0.11.1",
-    "netCDF4",
     "dask",
 ]
 
@@ -60,7 +58,10 @@ test = [
     "mypy==1.19.1",
     "types-PyYAML",
     "geopandas",
+    "netCDF4",  # needed for save/load tests
 ]
+
+netcdf = ["netCDF4"]
 
 notebooks = ["nbformat", "nbconvert", "jupyter", "plotly", "shapely", "seaborn"]
 

--- a/src/modelskill/comparison/_comparison.py
+++ b/src/modelskill/comparison/_comparison.py
@@ -1216,6 +1216,11 @@ class Comparer:
         ----------
         filename : str or Path
             filename
+
+        Raises
+        ------
+        ImportError
+            If netCDF4 is not installed
         """
         ds = self.data
 
@@ -1234,7 +1239,15 @@ class Comparer:
                 # da = ds_mod.to_xarray()[key]
                 ds["_raw_" + key] = ts_mod.data[key]
 
-        ds.to_netcdf(filename)
+        try:
+            ds.to_netcdf(filename)
+        except (ImportError, ValueError) as e:
+            if "netCDF4" in str(e) or "No module named" in str(e):
+                raise ImportError(
+                    "netCDF4 is required for saving to NetCDF format. "
+                    "Install it with: pip install modelskill[netcdf]"
+                ) from e
+            raise
 
     @staticmethod
     def load(filename: Union[str, Path]) -> "Comparer":
@@ -1248,9 +1261,22 @@ class Comparer:
         Returns
         -------
         Comparer
+
+        Raises
+        ------
+        ImportError
+            If netCDF4 is not installed
         """
-        with xr.open_dataset(filename) as ds:
-            data = ds.load()
+        try:
+            with xr.open_dataset(filename) as ds:
+                data = ds.load()
+        except (ImportError, ValueError) as e:
+            if "netCDF4" in str(e) or "No module named" in str(e):
+                raise ImportError(
+                    "netCDF4 is required for loading NetCDF files. "
+                    "Install it with: pip install modelskill[netcdf]"
+                ) from e
+            raise
 
         if data.gtype == "track":
             return Comparer(matched_data=data)


### PR DESCRIPTION
## Summary

Makes netCDF4 an optional dependency that can be installed with `pip install modelskill[netcdf]`.

## Changes

- Moved netCDF4 from main dependencies to optional `netcdf` dependency group in pyproject.toml
- Removed duplicate netCDF4 from dev dependencies
- Added netCDF4 to test dependencies (needed for save/load tests)
- Added helpful error messages in `Comparer.save()` and `Comparer.load()` methods
- Updated installation documentation in README.md and getting-started guide

## Rationale

- I/O (save/load of Comparer objects) is not core functionality of modelskill
- Core features (matching, comparing, skill calculation, plotting) work without netCDF4
- Users who don't need to save/load Comparer objects don't need this dependency
- Aligns with xarray's approach where netCDF4 is optional
- Reduces installation complexity, especially for users who only work with MIKE file formats

## Test plan

- [x] Existing save/load tests pass (netCDF4 is in test dependencies)
- [x] Type checking passes
- [x] Code provides clear error messages when netCDF4 is missing
- [x] Documentation updated