### PR TITLE
Use pandas[output_formatting] extra instead of direct jinja2 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,12 @@ name = "modelskill"
 version = "1.4.dev0"
 dependencies = [
     "numpy  > 1.24.4",
-    "pandas >= 1.4",
+    "pandas[output_formatting] >= 1.4",
     "mikeio >= 1.2",
     "matplotlib",
     "xarray",
     "netCDF4",
     "scipy",
-    "jinja2", # used for skill.style
 ]
 
 authors = [


### PR DESCRIPTION
## Summary
- Changed from directly specifying jinja2 to using pandas[output_formatting] extra
- Reduces direct dependencies and makes the relationship explicit
- pandas manages jinja2 version compatibility

## Verification
- All 589 tests pass
- SkillTable styling functionality verified working