### PR TITLE
Replace inplace=True in metrics for pandas 3.0 compatibility

### DIFF
--- a/src/modelskill/metrics.py
+++ b/src/modelskill/metrics.py
@@ -632,7 +632,7 @@ def peak_ratio(
         }
     )
     df_filter["Maximum"] = df_filter.max(axis=1)
-    df_filter.sort_values(by="Maximum", ascending=False, inplace=True)
+    df_filter = df_filter.sort_values(by="Maximum", ascending=False)
     # Finally we do the selection of the N- largest peaks from either model or measured
     df_filter = df_filter.iloc[0:top_n_peaks, :]
     # Rename to avoid further refactoring


### PR DESCRIPTION
## Summary
- Remove `inplace=True` parameter from `sort_values()` call in `peak_ratio()` metric
- Use assignment pattern instead: `df = df.sort_values(...)` 

## Motivation
Pandas 3.0 will remove the `inplace` parameter from all DataFrame/Series methods. This change ensures forward compatibility.

## Changes
- `src/modelskill/metrics.py:635` - Changed from `df_filter.sort_values(..., inplace=True)` to `df_filter = df_filter.sort_values(...)`