### PR TITLE
Don't mutate inputs

### DIFF
--- a/src/modelskill/comparison/_comparison.py
+++ b/src/modelskill/comparison/_comparison.py
@@ -341,10 +341,12 @@ def _matched_data_to_xarray(
                 f"Model data: {m} is of type {df[m].dtype}, it must be numeric"
             )
 
-    df = df[items.all]
-    df.index.name = "time"
-    df = df.rename(columns={items.obs: "Observation"})
-    ds = df.to_xarray()
+    ds = (
+        df.loc[:, items.all]
+        .rename_axis("time")
+        .rename(columns={items.obs: "Observation"})
+        .to_xarray()
+    )
     assert isinstance(ds, xr.Dataset)
 
     ds.attrs["name"] = name if name is not None else items.obs

--- a/tests/test_comparer.py
+++ b/tests/test_comparer.py
@@ -94,6 +94,8 @@ def tc() -> Comparer:
 
 
 def test_matched_df(pt_df):
+    # modelskill doesn't care about the name of the index, but it should be preserved
+    pt_df.index.name = "dato_tid"
     cmp = Comparer.from_matched_data(data=pt_df)
     assert cmp.gtype == "point"
     assert "m2" in cmp.mod_names
@@ -103,6 +105,14 @@ def test_matched_df(pt_df):
     assert cmp.name == "Observation"
     assert cmp.score()["m1"] == pytest.approx(0.5916079783099617)
     assert cmp.score()["m2"] == pytest.approx(0.15811388300841905)
+
+    # from_matched doesn't modify the original dataframe,. including the name of the index
+    assert pt_df.index.name == "dato_tid"
+    assert list(pt_df.columns) == ["Observation", "m1", "m2"]
+
+    # but to_dataframe always returns a dataframe with index named "time"
+    df2 = cmp.to_dataframe()
+    assert df2.index.name == "time"
 
 
 def test_matched_skill_geodataframe(pt_df):


### PR DESCRIPTION
This error was not present earlier, since we typically use time as the name of the index, and also modify it to time.

But modelskill should not modify inputs, that is a bug.