### PR TITLE
Remove value-based coloring from tracks in spatial_overview

### DIFF
--- a/src/modelskill/plotting/_spatial_overview.py
+++ b/src/modelskill/plotting/_spatial_overview.py
@@ -86,7 +86,7 @@ def spatial_overview(
             ax.scatter(x=o.x, y=o.y, marker="x")
         elif isinstance(o, TrackObservation):
             if o.n_points < 10000:
-                ax.scatter(x=o.x, y=o.y, c=o.values, marker=".", cmap="Reds")
+                ax.scatter(x=o.x, y=o.y, marker=".")
             else:
                 print(f"{o.name}: Too many points to plot")
                 # TODO: group by lonlat bin or sample randomly


### PR DESCRIPTION
## Summary
- Track observations in `spatial_overview` now use a uniform color instead of being colored by their values
- The previous value-based coloring (using "Reds" colormap) was confusing since there was no colorbar or legend to explain the colors (title says coverage, which could be interpreted as n data points per pixel)
- The purpose of `spatial_overview` is to show where observations are located, not what values they contain

This change will make it easier to remove/refactor the confusing [`Comparer._to_observation()`](https://github.com/DHI/modelskill/blob/2d8d8604e5704b20533d82564a27ec758d08bdfc/src/modelskill/comparison/_comparison.py#L710)

(Looking at the plot, it would be nice to have an option to exclude data outside the model domain, but we'll ignore that for now)

## Before
<img width="853" height="789" alt="spatial_overview_before" src="https://github.com/user-attachments/assets/f697af12-f5d1-49d7-b407-bdef9f7c4728" />

## After

<img width="853" height="789" alt="spatial_overview_after" src="https://github.com/user-attachments/assets/a73dd2fa-719d-4802-9809-61f979d0e7d9" />
