### PR TITLE
Remove _to_observation and _to_model from Comparer

### DIFF
--- a/src/modelskill/comparison/_collection_plotter.py
+++ b/src/modelskill/comparison/_collection_plotter.py
@@ -804,10 +804,9 @@ class ComparerCollectionPlotter:
         """
         from ..plotting import spatial_overview
 
-        obs = [cmp._to_observation() for cmp in self.cc]
         # TODO how to add model domain(s)
 
-        return spatial_overview(obs, ax=ax, figsize=figsize, title=title)
+        return spatial_overview(self.cc, ax=ax, figsize=figsize, title=title)
 
     def temporal_coverage(
         self,
@@ -835,11 +834,10 @@ class ComparerCollectionPlotter:
         """
         from ..plotting import temporal_coverage
 
-        obs = [cmp._to_observation() for cmp in self.cc]
-        mod = self.cc[0]._to_model()
+        mod = list(self.cc[0].raw_mod_data.values())
 
         return temporal_coverage(
-            obs=obs,
+            obs=list(self.cc),
             mod=mod,
             limit_to_model_period=limit_to_model_period,
             marker=marker,

--- a/src/modelskill/comparison/_comparison.py
+++ b/src/modelskill/comparison/_comparison.py
@@ -24,7 +24,6 @@ from copy import deepcopy
 from .. import metrics as mtr
 from .. import Quantity
 from ..types import GeometryType
-from ..obs import PointObservation, TrackObservation
 from ..model import PointModelResult, TrackModelResult
 from ..timeseries._timeseries import _validate_data_var_name
 from ._comparer_plotter import ComparerPlotter
@@ -706,37 +705,6 @@ class Comparer:
                 raw_mod_data[k] = v
 
         return Comparer(matched_data=data, raw_mod_data=raw_mod_data)
-
-    def _to_observation(self) -> PointObservation | TrackObservation:
-        """Convert to Observation"""
-        if self.gtype == "point":
-            df = self.data.drop_vars(["x", "y", "z"])[self._obs_str].to_dataframe()
-            return PointObservation(
-                data=df,
-                name=self.name,
-                x=self.x,
-                y=self.y,
-                z=self.z,
-                quantity=self.quantity,
-                # TODO: add attrs
-            )
-        elif self.gtype == "track":
-            df = self.data.drop_vars(["z"])[[self._obs_str]].to_dataframe()
-            return TrackObservation(
-                data=df,
-                item=0,
-                x_item=1,
-                y_item=2,
-                name=self.name,
-                quantity=self.quantity,
-                # TODO: add attrs
-            )
-        else:
-            raise NotImplementedError(f"Unknown gtype: {self.gtype}")
-
-    def _to_model(self) -> list[PointModelResult | TrackModelResult]:
-        mods = list(self.raw_mod_data.values())
-        return mods
 
     def __add__(self, other):
         warnings.warn(


### PR DESCRIPTION
## Summary
- Remove `_to_observation()` and `_to_model()` methods from Comparer
- `spatial_overview` and `temporal_coverage` now work directly with Comparers via duck typing
- Uses `gtype` property instead of `isinstance()` checks, making it easier to add new observation types

Follow-up to #565 which removed value-based coloring to enable this refactor.