### PR TITLE
Move quarto-cli to separate docs dependency group

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
         enable-cache: true
 
     - name: Install dependencies
-      run: uv sync --dev
+      run: uv sync --group dev --group docs
     
     - name: Build documentation
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,13 @@ dev = [
     "pytest",
     "plotly >= 4.5",
     "ruff==0.6.2",
-    "quarto-cli==1.5.57",
-    "quartodoc==0.11.1",
     "netCDF4",
     "dask",
+]
+
+docs = [
+    "quarto-cli==1.5.57",
+    "quartodoc==0.11.1",
 ]
 
 test = [


### PR DESCRIPTION
## Summary

The Quarto PyPI wheel contains deeply nested Deno std cache files that exceed Windows' MAX_PATH limit (~260 chars), causing `uv sync --dev` to fail on Windows.

Fix: move `quarto-cli` and `quartodoc` to a dedicated `docs` dependency group so they're only installed when explicitly needed (CI docs build, or `uv sync --group docs` locally).