### PR TITLE
Remove quarto-cli pip package, install via CI action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,9 +17,14 @@ jobs:
         python-version: "3.14"
         enable-cache: true
 
+    - name: Set up Quarto
+      uses: quarto-dev/quarto-actions/setup@v2
+      with:
+        version: "1.8.27"
+
     - name: Install dependencies
       run: uv sync --group dev --group docs
-    
+
     - name: Build documentation
       run: |
         make docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,15 @@
    ```
 6. Make a pull request with a clear summary of the changes
 
+## Building documentation locally
+
+To build the docs locally, install [Quarto](https://quarto.org/docs/get-started/) (version is specified in the [CI workflow](.github/workflows/docs.yml)), then:
+
+```bash
+uv sync --group docs
+make docs
+```
+
 ## Running specific tests
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dev = [
 ]
 
 docs = [
-    "quarto-cli==1.5.57",
     "quartodoc==0.11.1",
     "griffe<2",
 ]


### PR DESCRIPTION
- Remove `quarto-cli` from `pyproject.toml` docs dependencies (doesn't build on Windows)
- Install Quarto via `quarto-dev/quarto-actions/setup@v2` in CI (pinned to 1.8.27)
- Add "Building documentation locally" section to CONTRIBUTING.md