### PR TITLE
Rename edge to reach throughout network extension

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -82,7 +82,7 @@ website:
             - api/PointObservation.qmd
             - api/TrackObservation.qmd
             - api/NodeObservation.qmd
-            - api/EdgeObservation.qmd
+            - api/ReachObservation.qmd
         - section: "Model Result"
           href: api/model.qmd
           contents:
@@ -171,7 +171,7 @@ quartodoc:
         - PointObservation
         - TrackObservation
         - NodeObservation
-        - EdgeObservation
+        - ReachObservation
     - title: Model Result
       desc: ""
       contents:

--- a/docs/user-guide/network.qmd
+++ b/docs/user-guide/network.qmd
@@ -180,7 +180,7 @@ Large Res1D files can contain thousands of nodes and gridpoints. Loading all of 
 | `reaches` | `None` \| `str` \| `list[str]` | Control which reaches have intermediate gridpoint data populated. `None` (default) loads everything; `[]` skips all gridpoints; a name or list of names loads only those reaches. |
 
 ::: {.callout-note}
-Selective loading only controls **which timeseries are held in memory**. The full network topology (nodes, edges, lengths) is always constructed so that `find()`, `recall()`, and graph algorithms still work on the complete network.
+Selective loading only controls **which timeseries are held in memory**. The full network topology (nodes, reaches, lengths) is always constructed so that `find()`, `recall()`, and graph algorithms still work on the complete network.
 :::
 
 The most memory-efficient setup — useful when you only care about specific junction nodes — is to pass the node IDs you need and skip all intermediate gridpoints with `reaches=[]`:

--- a/docs/user-guide/network.qmd
+++ b/docs/user-guide/network.qmd
@@ -28,7 +28,7 @@ uv add modelskill[networks]
 import pandas as pd
 import numpy as np
 from typing import Any
-from modelskill.network import Network, NetworkNode, NetworkEdge, EdgeBreakPoint
+from modelskill.network import Network, NetworkNode, NetworkReach, ReachBreakPoint
 
 
 class ExampleNode(NetworkNode):
@@ -51,18 +51,18 @@ class ExampleNode(NetworkNode):
         return {}
 
 
-class ExampleEdge(NetworkEdge):
-    """Edge connecting two nodes with a given length."""
+class ExampleReach(NetworkReach):
+    """Reach connecting two nodes with a given length."""
 
     def __init__(
         self,
-        edge_id: str,
+        reach_id: str,
         start: NetworkNode,
         end: NetworkNode,
         length: float,
         breakpoints: list | None = None,
     ):
-        self._id = edge_id
+        self._id = reach_id
         self._start = start
         self._end = end
         self._length = length
@@ -89,9 +89,9 @@ class ExampleEdge(NetworkEdge):
         return self._breakpoints
 
 
-class ExampleBreakPoint(EdgeBreakPoint):
-    def __init__(self, edge_id: str, distance: float, data: pd.DataFrame):
-        self._id = (edge_id, distance)
+class ExampleBreakPoint(ReachBreakPoint):
+    def __init__(self, reach_id: str, distance: float, data: pd.DataFrame):
+        self._id = (reach_id, distance)
         self._data = data
 
     @property
@@ -117,12 +117,12 @@ node_s2 = ExampleNode("sensor_2", df2)
 node_s3 = ExampleNode("sensor_3", df3)
 
 bp = ExampleBreakPoint("r1", 200.0, df4)
-edge1 = ExampleEdge("r1", node_s1, node_s2, length=500.0, breakpoints=[bp])
-edge2 = ExampleEdge("r2", node_s2, node_s3, length=300.0)
-network = Network(edges=[edge1, edge2])
+reach1 = ExampleReach("r1", node_s1, node_s2, length=500.0, breakpoints=[bp])
+reach2 = ExampleReach("r2", node_s2, node_s3, length=300.0)
+network = Network(reaches=[reach1, reach2])
 ```
 
-A **Network** represents a 1D pipe or river network as a directed graph: nodes hold timeseries data (e.g. water level at a junction) and edges carry the topology and reach length between them.  Break points along an edge (e.g. cross-section chainages) are supported as observation locations too.
+A **Network** represents a 1D pipe or river network as a directed graph: nodes hold timeseries data (e.g. water level at a junction) and reaches carry the topology and reach length between them.  Break points along a reach (e.g. cross-section chainages) are supported as observation locations too.
 
 The typical workflow is:
 
@@ -262,7 +262,7 @@ network.to_dataframe(sel="WaterLevel").head()
 After construction, nodes are re-labelled as integers.  Use `find()` to go from original coordinates to the integer ID and `recall()` to go back.
 
 ::: {.callout-tip}
-When creating `NodeObservation` objects for skill assessment you generally do **not** need to call `find()`.  You can pass the original string ID as `node=`, and `NetworkModelResult` will resolve it for you during matching.  For breakpoints, use `at=(edge, distance)` rather than `node=`.  See [Skill assessment workflow](#skill-assessment-workflow) for details.
+When creating `NodeObservation` objects for skill assessment you generally do **not** need to call `find()`.  You can pass the original string ID as `node=`, and `NetworkModelResult` will resolve it for you during matching.  For breakpoints, use `at=(reach, distance)` rather than `node=`.  See [Skill assessment workflow](#skill-assessment-workflow) for details.
 :::
 
 ```{python}
@@ -276,7 +276,7 @@ print(network.recall(node_id))
 
 ```{python}
 # Look up a break point by reach + chainage
-bp_id = network.find(edge="94l1", distance=21.285)
+bp_id = network.find(reach="94l1", distance=21.285)
 print(f"Break point (94l1, 21.285) → integer id {bp_id}")
 print(network.recall(bp_id))
 ```
@@ -288,12 +288,12 @@ print(ids)
 ```
 
 ```{python}
-# Edge lookup
-ids = network.find(edge="58l1", distance="start")
+# Reach lookup
+ids = network.find(reach="58l1", distance="start")
 print(ids)
-ids = network.find(edge="58l1", distance=[51.456, 77.185])
+ids = network.find(reach="58l1", distance=[51.456, 77.185])
 print(ids)
-ids = network.find(edge="58l1", distance=["start", 77.185])
+ids = network.find(reach="58l1", distance=["start", 77.185])
 print(ids)
 ```
 
@@ -331,9 +331,9 @@ cc.skill()
 Resolution happens inside `ms.match()`.  If the string is not found in the network's alias map a `ValueError` is raised with a clear message indicating which alias could not be resolved.
 :::
 
-#### Option B — breakpoint by `(edge, distance)` tuple
+#### Option B — breakpoint by `(reach, distance)` tuple
 
-When your observation sits at a chainage along a reach rather than at a named junction node, you can use the `at` argument and pass a `(edge_id, distance)` tuple.  The `NetworkModelResult` looks up the corresponding breakpoint at match time:
+When your observation sits at a chainage along a reach rather than at a named junction node, you can use the `at` argument and pass a `(reach_id, distance)` tuple.  The `NetworkModelResult` looks up the corresponding breakpoint at match time:
 
 ```python
 obs_bp = ms.NodeObservation(path_to_sensor_data_1, at=("94l1", 21.285))
@@ -342,7 +342,7 @@ cc = ms.match(obs=obs_bp, mod=mr)
 cc.skill()
 ```
 
-The tuple form is equivalent to calling `network.find(edge="94l1", distance=21.285)` beforehand and is resolved during matching.
+The tuple form is equivalent to calling `network.find(reach="94l1", distance=21.285)` beforehand and is resolved during matching.
 
 ::: {.callout-note}
 ## Chainage tolerance
@@ -350,14 +350,14 @@ The tuple form is equivalent to calling `network.find(edge="94l1", distance=21.2
 Breakpoint distances are matched with a tolerance of **1 × 10⁻³** (i.e. ±0.001 in whatever distance units the network uses).  This means that small floating-point discrepancies between the distance you type and the value stored in the network are handled gracefully.  If no breakpoint falls within that tolerance a `ValueError` is raised.
 :::
 
-### 3. Using EdgeObservation for edge-uniform quantities
+### 3. Using ReachObservation for reach-uniform quantities
 
-Some physical quantities — such as **discharge in a pipe** — are conceptually uniform across the whole edge, even though the model stores values at individual breakpoints along the reach. `EdgeObservation` lets you associate a timeseries with a named edge without having to identify a specific breakpoint.
+Some physical quantities — such as **discharge in a pipe** — are conceptually uniform across the whole reach, even though the model stores values at individual breakpoints along the reach. `ReachObservation` lets you associate a timeseries with a named reach without having to identify a specific breakpoint.
 
-When matched against a `NetworkModelResult`, modelskill automatically extracts model data from an arbitrary breakpoint that belongs to the given edge and verifies that all breakpoints on the edge carry equivalent values.
+When matched against a `NetworkModelResult`, modelskill automatically extracts model data from an arbitrary breakpoint that belongs to the given reach and verifies that all breakpoints on the reach carry equivalent values.
 
 ```{python}
-obs_q = ms.EdgeObservation(path_to_sensor_data_1, edge="94l1", name="Q_94l1")
+obs_q = ms.ReachObservation(path_to_sensor_data_1, reach="94l1", name="Q_94l1")
 obs_q
 ```
 
@@ -370,17 +370,17 @@ cc_q.skill()
 ```
 
 ::: {.callout-note}
-Use `EdgeObservation` when your measured quantity is representative of the whole reach (e.g. discharge, which is constant along a reach in steady flow).  If you need to compare a quantity that varies spatially along the edge (e.g. water level at a specific chainage), use a `NodeObservation` with a `(edge, distance)` tuple instead (see [Option C](#option-c-breakpoint-by-edge-distance-tuple) above).
+Use `ReachObservation` when your measured quantity is representative of the whole reach (e.g. discharge, which is constant along a reach in steady flow).  If you need to compare a quantity that varies spatially along the reach (e.g. water level at a specific chainage), use a `NodeObservation` with a `(reach, distance)` tuple instead (see [Option B](#option-b-breakpoint-by-reach-distance-tuple) above).
 :::
 
 ## Development
 
 ### Custom network formats
 
-In case you have your network data in a format that is not included in [Building a Network](#building-a-network), you can assemble a `Network` object by subclassing the abstract base classes `NetworkNode` and `NetworkEdge`.
+In case you have your network data in a format that is not included in [Building a Network](#building-a-network), you can assemble a `Network` object by subclassing the abstract base classes `NetworkNode` and `NetworkReach`.
 
 `NetworkNode` requires three properties: `id`, `data`, and `boundary`.
-`NetworkEdge` requires five: `id`, `start`, `end`, `length`, and `breakpoints`.
+`NetworkReach` requires five: `id`, `start`, `end`, `length`, and `breakpoints`.
 
 
 The following is a simple implementation example:
@@ -389,7 +389,7 @@ The following is a simple implementation example:
 import pandas as pd
 import numpy as np
 from typing import Any
-from modelskill.network import NetworkNode, NetworkEdge, Network
+from modelskill.network import NetworkNode, NetworkReach, Network
 
 
 class ExampleNode(NetworkNode):
@@ -412,14 +412,14 @@ class ExampleNode(NetworkNode):
         return {}
 
 
-class ExampleEdge(NetworkEdge):
-    """Edge connecting two nodes with a given length."""
+class ExampleReach(NetworkReach):
+    """Reach connecting two nodes with a given length."""
 
     def __init__(
-        self, edge_id: str, start: NetworkNode, end: NetworkNode, length: float,
+        self, reach_id: str, start: NetworkNode, end: NetworkNode, length: float,
         breakpoints: list | None = None,
     ):
-        self._id = edge_id
+        self._id = reach_id
         self._start = start
         self._end = end
         self._length = length
@@ -447,7 +447,7 @@ class ExampleEdge(NetworkEdge):
 ```
 
 ::: {.callout-tip}
-The three abstract properties that **every** `NetworkNode` subclass must implement are `id`, `data` and `boundary`. If `boundary` is not relevant for your use case, define the property to return an empty dictionary, as in the example above. Similarly, a `NetworkEdge` with no intermediate points can return an empty `breakpoints` list.
+The three abstract properties that **every** `NetworkNode` subclass must implement are `id`, `data` and `boundary`. If `boundary` is not relevant for your use case, define the property to return an empty dictionary, as in the example above. Similarly, a `NetworkReach` with no intermediate points can return an empty `breakpoints` list.
 :::
 
 
@@ -459,24 +459,24 @@ node_s1 = ExampleNode("sensor_1", df1)
 node_s2 = ExampleNode("sensor_2", df2)
 node_s3 = ExampleNode("sensor_3", df3)
 
-edge1 = ExampleEdge("r1", node_s1, node_s2, length=500.0)
-edge2 = ExampleEdge("r2", node_s2, node_s3, length=300.0)
+reach1 = ExampleReach("r1", node_s1, node_s2, length=500.0)
+reach2 = ExampleReach("r2", node_s2, node_s3, length=300.0)
 
-network = Network(edges=[edge1, edge2])
+network = Network(reaches=[reach1, reach2])
 network
 ```
 
 ### Adding break points along a reach
 
-Break points represent intermediate chainage locations on a reach (e.g. cross-sections).  Subclass `EdgeBreakPoint` the same way — implement `id` (a `(edge_id, distance)` tuple) and `data`:
+Break points represent intermediate chainage locations on a reach (e.g. cross-sections).  Subclass `ReachBreakPoint` the same way — implement `id` (a `(reach_id, distance)` tuple) and `data`:
 
 ```python
-from modelskill.network import EdgeBreakPoint
+from modelskill.network import ReachBreakPoint
 
 
-class ExampleBreakPoint(EdgeBreakPoint):
-    def __init__(self, edge_id: str, distance: float, data: pd.DataFrame):
-        self._id = (edge_id, distance)
+class ExampleBreakPoint(ReachBreakPoint):
+    def __init__(self, reach_id: str, distance: float, data: pd.DataFrame):
+        self._id = (reach_id, distance)
         self._data = data
 
     @property
@@ -490,9 +490,9 @@ class ExampleBreakPoint(EdgeBreakPoint):
 
 # df4 is a DataFrame object that has been loaded in memory
 bp = ExampleBreakPoint("r1", 200.0, df4)
-edge1 = ExampleEdge("r1", node_s1, node_s2, length=500.0, breakpoints=[bp])
-edge2 = ExampleEdge("r2", node_s2, node_s3, length=300.0)
-network = Network(edges=[edge1, edge2])
+reach1 = ExampleReach("r1", node_s1, node_s2, length=500.0, breakpoints=[bp])
+reach2 = ExampleReach("r2", node_s2, node_s3, length=300.0)
+network = Network(reaches=[reach1, reach2])
 ```
 
 
@@ -500,4 +500,4 @@ network = Network(edges=[edge1, edge2])
 
 * [API reference — NetworkModelResult](../api/NetworkModelResult.qmd)
 * [API reference — NodeObservation](../api/NodeObservation.qmd)
-* [API reference — EdgeObservation](../api/EdgeObservation.qmd)
+* [API reference — ReachObservation](../api/ReachObservation.qmd)

--- a/src/modelskill/__init__.py
+++ b/src/modelskill/__init__.py
@@ -46,7 +46,7 @@ from .obs import (
     PointObservation,
     TrackObservation,
     NodeObservation,
-    EdgeObservation,
+    ReachObservation,
 )
 from .matching import from_matched, match
 from .configuration import from_config
@@ -102,7 +102,7 @@ __all__ = [
     "PointObservation",
     "TrackObservation",
     "NodeObservation",
-    "EdgeObservation",
+    "ReachObservation",
     "TimeSeries",
     "match",
     "from_matched",

--- a/src/modelskill/matching.py
+++ b/src/modelskill/matching.py
@@ -34,7 +34,7 @@ from .obs import (
     PointObservation,
     TrackObservation,
     NodeObservation,
-    EdgeObservation,
+    ReachObservation,
 )
 from .timeseries import TimeSeries
 from .types import Period
@@ -72,7 +72,7 @@ ObsTypes = Union[
     PointObservation,
     TrackObservation,
     NodeObservation,
-    EdgeObservation,
+    ReachObservation,
 ]
 ObsInputType = Union[
     str,
@@ -407,8 +407,8 @@ def _match_space_time(
             case NodeModelResult() as nmr, NodeObservation():
                 # mr is the extracted NodeModelResult
                 aligned = align_data(nmr.data, observation, max_gap=max_model_gap)
-            case NodeModelResult() as nmr, EdgeObservation():
-                # EdgeObservation is extracted to a NodeModelResult (any breakpoint on the edge)
+            case NodeModelResult() as nmr, ReachObservation():
+                # ReachObservation is extracted to a NodeModelResult (any breakpoint on the reach)
                 aligned = align_data(nmr.data, observation, max_gap=max_model_gap)
             case _:
                 raise TypeError(

--- a/src/modelskill/model/adapters/_res1d.py
+++ b/src/modelskill/model/adapters/_res1d.py
@@ -7,7 +7,7 @@ import pandas as pd
 if TYPE_CHECKING:
     from mikeio1d.result_network import ResultNode, ResultGridPoint, ResultReach
 
-from modelskill.network import NetworkNode, EdgeBreakPoint, NetworkEdge
+from modelskill.network import NetworkNode, ReachBreakPoint, NetworkReach
 
 
 def _simplify_colnames(node: ResultNode | ResultGridPoint) -> pd.DataFrame:
@@ -58,7 +58,7 @@ class Res1DNode(NetworkNode):
         return self._boundary
 
 
-class GridPoint(EdgeBreakPoint):
+class GridPoint(ReachBreakPoint):
     def __init__(
         self, reach_id: str, chainage: float, data: pd.DataFrame | None = None
     ):
@@ -74,8 +74,8 @@ class GridPoint(EdgeBreakPoint):
         return self._data
 
 
-class Res1DReach(NetworkEdge):
-    """NetworkEdge adapter for a mikeio1d ResultReach."""
+class Res1DReach(NetworkReach):
+    """NetworkReach adapter for a mikeio1d ResultReach."""
 
     def __init__(
         self,
@@ -99,7 +99,7 @@ class Res1DReach(NetworkEdge):
         self._start = start_node
         self._end = end_node
         self._length = reach.length
-        self._breakpoints: list[EdgeBreakPoint] = [
+        self._breakpoints: list[ReachBreakPoint] = [
             GridPoint(
                 gridpoint.reach_name,
                 gridpoint.chainage,
@@ -125,5 +125,5 @@ class Res1DReach(NetworkEdge):
         return self._length
 
     @property
-    def breakpoints(self) -> list[EdgeBreakPoint]:
+    def breakpoints(self) -> list[ReachBreakPoint]:
         return self._breakpoints

--- a/src/modelskill/model/network.py
+++ b/src/modelskill/model/network.py
@@ -9,7 +9,7 @@ import xarray as xr
 
 from modelskill.timeseries import TimeSeries, _parse_network_node_input
 from ._base import SelectedItems
-from ..obs import NodeObservation, EdgeObservation
+from ..obs import NodeObservation, ReachObservation
 from ..quantity import Quantity
 from ..types import PointType
 
@@ -114,7 +114,7 @@ class NetworkModelResult:
     --------
     >>> import modelskill as ms
     >>> from modelskill.network import Network
-    >>> network = Network(edges)  # edges is a list[NetworkEdge]
+    >>> network = Network(reaches)  # reaches is a list[NetworkReach]
     >>> mr = ms.NetworkModelResult(network, name="MyModel")
     >>> obs = ms.NodeObservation(data, node=network.find(node="node_A"))
     >>> extracted = mr.extract(obs)
@@ -166,14 +166,14 @@ class NetworkModelResult:
 
     def extract(
         self,
-        observation: NodeObservation | EdgeObservation,
+        observation: NodeObservation | ReachObservation,
     ) -> NodeModelResult:
-        """Extract ModelResult at exact node or edge locations
+        """Extract ModelResult at exact node or reach locations
 
         Parameters
         ----------
-        observation : NodeObservation or EdgeObservation
-            observation with node ID or edge ID
+        observation : NodeObservation or ReachObservation
+            observation with node ID or reach ID
 
         Returns
         -------
@@ -182,11 +182,11 @@ class NetworkModelResult:
         """
         if isinstance(observation, NodeObservation):
             return self._extract_node(observation)
-        elif isinstance(observation, EdgeObservation):
-            return self._extract_edge(observation)
+        elif isinstance(observation, ReachObservation):
+            return self._extract_reach(observation)
         else:
             raise TypeError(
-                f"NetworkModelResult supports NodeObservation and EdgeObservation, got {type(observation).__name__}"
+                f"NetworkModelResult supports NodeObservation and ReachObservation, got {type(observation).__name__}"
             )
 
     def _extract_node(self, observation: NodeObservation) -> NodeModelResult:
@@ -206,36 +206,36 @@ class NetworkModelResult:
             aux_items=self.sel_items.aux,
         )
 
-    def _extract_edge(self, observation: EdgeObservation) -> NodeModelResult:
-        # Extract model result from an arbitrary breakpoint belonging to the edge.
+    def _extract_reach(self, observation: ReachObservation) -> NodeModelResult:
+        # Extract model result from an arbitrary breakpoint belonging to the reach.
 
-        # Searches the alias map for breakpoints whose edge component matches
-        # ``observation.edge``, then returns the first one that has data in the
+        # Searches the alias map for breakpoints whose reach component matches
+        # ``observation.reach``, then returns the first one that has data in the
         # dataset.  Raises if no breakpoint with data is found or if the quantity
-        # is not present for any breakpoint of that edge.
+        # is not present for any breakpoint of that reach.
 
         item = self.sel_items.values
-        edge_id = observation.edge
+        reach_id = observation.reach
 
         try:
-            edge = self.network._edges[edge_id]
+            reach = self.network._reaches[reach_id]
         except KeyError:
-            raise ValueError(f"Edge {edge_id} not found in network.")
+            raise ValueError(f"Reach {reach_id} not found in network.")
 
-        # This only searches intermediate breakpoints since edge-level data is not
+        # This only searches intermediate breakpoints since reach-level data is not
         # expected in nodes.
 
         available_nodes = {int(node_id) for node_id in self.data.node.values}
         found_ds = None
         found_int_id: int | None = None
         missing_node_data = False
-        for breakpoint in edge.breakpoints:
+        for breakpoint in reach.breakpoints:
             if breakpoint.data is None:
                 continue
             if item not in breakpoint.data.columns:
                 continue
 
-            int_id = self.network.find(edge=breakpoint.id[0], distance=breakpoint.distance)
+            int_id = self.network.find(reach=breakpoint.id[0], distance=breakpoint.distance)
             if int_id not in available_nodes:
                 missing_node_data = True
                 continue
@@ -246,7 +246,7 @@ class NetworkModelResult:
                 if not np.allclose(da1.values, da2.values, equal_nan=True):
                     raise ValueError(
                         "Not all data in breakpoints are equivalent. "
-                        "Select a specific node instead of the edge."
+                        "Select a specific node instead of the reach."
                     )
             else:
                 found_ds = ds
@@ -263,14 +263,14 @@ class NetworkModelResult:
             )
         if missing_node_data:
             raise ValueError(
-                f"Edge '{edge_id}' has breakpoint data for quantity "
+                f"Reach '{reach_id}' has breakpoint data for quantity "
                 f"'{item}', but matching breakpoint nodes are "
                 "missing from the model dataset. Re-create the NetworkModelResult "
                 "with the relevant reaches populated."
             )
 
         raise ValueError(
-            f"Edge '{edge_id}' was found in the network but none of its "
+            f"Reach '{reach_id}' was found in the network but none of its "
             f"breakpoints have data loaded for quantity '{self.sel_items.values}'. "
             f"Re-create the NetworkModelResult with the relevant reaches populated."
         )
@@ -279,7 +279,7 @@ class NetworkModelResult:
         # Resolve a node alias to an internal node ID.
 
         # Breakpoint tuple aliases are matched first by exact key lookup and then
-        # by edge ID and distance within ``_CHAINAGE_TOLERANCE``. If multiple
+        # by reach ID and distance within ``_CHAINAGE_TOLERANCE``. If multiple
         # candidates are within tolerance, the closest distance is selected; ties
         # are broken by choosing the smallest node ID. Distance units are the
         # same as the network chainage units.
@@ -296,10 +296,10 @@ class NetworkModelResult:
 
             if isinstance(alias, tuple):
                 # Handle tolerances
-                edge_id, distance = alias
+                reach_id, distance = alias
                 candidates: list[tuple[float, int]] = []
                 for key, node_id in self.network._alias_map.items():
-                    if isinstance(key, tuple) and key[0] == edge_id:
+                    if isinstance(key, tuple) and key[0] == reach_id:
                         diff = abs(key[1] - distance)
                         if diff <= self._CHAINAGE_TOLERANCE:
                             candidates.append((diff, node_id))

--- a/src/modelskill/network.py
+++ b/src/modelskill/network.py
@@ -50,8 +50,8 @@ class NetworkNode(ABC):
     See Also
     --------
     BasicNode : Ready-to-use concrete implementation.
-    NetworkEdge : Connects two NetworkNode instances.
-    Network : Container that assembles nodes and edges into a graph.
+    NetworkReach : Connects two NetworkNode instances.
+    Network : Container that assembles nodes and reaches into a graph.
     """
 
     @property
@@ -78,30 +78,30 @@ class NetworkNode(ABC):
         return list(self.data.columns)
 
 
-class EdgeBreakPoint(ABC):
-    """Abstract base class for an intermediate break point along a network edge.
+class ReachBreakPoint(ABC):
+    """Abstract base class for an intermediate break point along a network reach.
 
-    Break points represent locations between the start and end nodes of an
-    edge (e.g. cross-section chainage points along a river reach) that carry
+    Break points represent locations between the start and end nodes of a
+    reach (e.g. cross-section chainage points along a river reach) that carry
     their own time-series data.
 
     Two properties must be implemented:
 
-    * :attr:`id` - a ``(edge_id, distance)`` tuple that uniquely locates the
+    * :attr:`id` - a ``(reach_id, distance)`` tuple that uniquely locates the
       break point within the network.
     * :attr:`data` - a time-indexed :class:`pandas.DataFrame` whose columns
       are quantity names.
 
     The :attr:`distance` convenience property returns ``id[1]`` (the
-    along-edge distance in the units used by the parent network).
+    along-reach distance in the units used by the parent network).
 
     Examples
     --------
     Minimal subclass:
 
-    >>> class MyBreakPoint(EdgeBreakPoint):
-    ...     def __init__(self, edge_id, chainage, df):
-    ...         self._id = (edge_id, chainage)
+    >>> class MyBreakPoint(ReachBreakPoint):
+    ...     def __init__(self, reach_id, chainage, df):
+    ...         self._id = (reach_id, chainage)
     ...         self._data = df
     ...     @property
     ...     def id(self): return self._id
@@ -110,15 +110,15 @@ class EdgeBreakPoint(ABC):
 
     See Also
     --------
-    NetworkEdge : Owns a list of EdgeBreakPoint instances.
-    NetworkNode : Represents a start/end node of an edge.
-    Network : Assembles edges (and their break points) into a graph.
+    NetworkReach : Owns a list of ReachBreakPoint instances.
+    NetworkNode : Represents a start/end node of a reach.
+    Network : Assembles reaches (and their break points) into a graph.
     """
 
     @property
     @abstractmethod
     def id(self) -> tuple[str, float]:
-        """``(edge_id, distance)`` tuple uniquely identifying this break point."""
+        """``(reach_id, distance)`` tuple uniquely identifying this break point."""
         pass
 
     @property
@@ -129,7 +129,7 @@ class EdgeBreakPoint(ABC):
 
     @property
     def distance(self) -> float:
-        """Along-edge distance of this break point (same units as :attr:`NetworkEdge.length`)."""
+        """Along-reach distance of this break point (same units as :attr:`NetworkReach.length`)."""
         return self.id[1]
 
     @property
@@ -138,35 +138,35 @@ class EdgeBreakPoint(ABC):
         return list(self.data.columns)
 
 
-class NetworkEdge(ABC):
-    """Abstract base class for an edge in a network.
+class NetworkReach(ABC):
+    """Abstract base class for a reach in a network.
 
-    An edge represents a directed connection between two :class:`NetworkNode`
+    A reach represents a directed connection between two :class:`NetworkNode`
     instances (e.g. a river reach between two junctions).  It may also carry
-    a list of :class:`EdgeBreakPoint` objects for intermediate chainage
+    a list of :class:`ReachBreakPoint` objects for intermediate chainage
     locations.
 
     Subclass this to integrate your own network topology.  Five properties
     must be implemented:
 
-    * :attr:`id` - a unique string identifier for the edge.
+    * :attr:`id` - a unique string identifier for the reach.
     * :attr:`start` - the upstream/start :class:`NetworkNode`.
     * :attr:`end` - the downstream/end :class:`NetworkNode`.
-    * :attr:`length` - total edge length (in the units of your coordinate
+    * :attr:`length` - total reach length (in the units of your coordinate
       system).
-    * :attr:`breakpoints` - list of :class:`EdgeBreakPoint` instances ordered
+    * :attr:`breakpoints` - list of :class:`ReachBreakPoint` instances ordered
       by increasing distance from the start node (empty list if none).
 
-    The concrete helper :class:`BasicEdge` is provided for the common case
+    The concrete helper :class:`BasicReach` is provided for the common case
     where all data is already available in memory.
 
     Examples
     --------
     Minimal subclass:
 
-    >>> class MyEdge(NetworkEdge):
-    ...     def __init__(self, eid, start_node, end_node, length):
-    ...         self._id = eid
+    >>> class MyReach(NetworkReach):
+    ...     def __init__(self, rid, start_node, end_node, length):
+    ...         self._id = rid
     ...         self._start = start_node
     ...         self._end = end_node
     ...         self._length = length
@@ -183,45 +183,45 @@ class NetworkEdge(ABC):
 
     See Also
     --------
-    BasicEdge : Ready-to-use concrete implementation.
-    NetworkNode : Represents the start/end of this edge.
-    EdgeBreakPoint : Intermediate data points along this edge.
-    Network : Assembles a list of NetworkEdge objects into a graph.
+    BasicReach : Ready-to-use concrete implementation.
+    NetworkNode : Represents the start/end of this reach.
+    ReachBreakPoint : Intermediate data points along this reach.
+    Network : Assembles a list of NetworkReach objects into a graph.
     """
 
     @property
     @abstractmethod
     def id(self) -> str:
-        """Unique string identifier for this edge."""
+        """Unique string identifier for this reach."""
         pass
 
     @property
     @abstractmethod
     def start(self) -> NetworkNode:
-        """Start (upstream) node of this edge."""
+        """Start (upstream) node of this reach."""
         pass
 
     @property
     @abstractmethod
     def end(self) -> NetworkNode:
-        """End (downstream) node of this edge."""
+        """End (downstream) node of this reach."""
         pass
 
     @property
     @abstractmethod
     def length(self) -> float:
-        """Total length of this edge in network units."""
+        """Total length of this reach in network units."""
         pass
 
     @property
     @abstractmethod
-    def breakpoints(self) -> list[EdgeBreakPoint]:
-        """Ordered list of intermediate :class:`EdgeBreakPoint` objects (may be empty)."""
+    def breakpoints(self) -> list[ReachBreakPoint]:
+        """Ordered list of intermediate :class:`ReachBreakPoint` objects (may be empty)."""
         pass
 
     @property
     def n_breakpoints(self) -> int:
-        """Number of break points in the edge."""
+        """Number of break points in the reach."""
         return len(self.breakpoints)
 
 
@@ -267,25 +267,25 @@ class BasicNode(NetworkNode):
         return self._boundary
 
 
-class BasicEdge(NetworkEdge):
-    """Concrete :class:`NetworkEdge` for programmatic network construction.
+class BasicReach(NetworkReach):
+    """Concrete :class:`NetworkReach` for programmatic network construction.
 
     Parameters
     ----------
     id : str
-        Unique edge identifier.
+        Unique reach identifier.
     start : NetworkNode
         Start node.
     end : NetworkNode
         End node.
     length : float
-        Edge length.
-    breakpoints : list[EdgeBreakPoint], optional
+        Reach length.
+    breakpoints : list[ReachBreakPoint], optional
         Intermediate break points, by default empty.
 
     Examples
     --------
-    >>> edge = BasicEdge("reach_1", node_a, node_b, length=250.0)
+    >>> reach = BasicReach("reach_1", node_a, node_b, length=250.0)
     """
 
     def __init__(
@@ -294,13 +294,13 @@ class BasicEdge(NetworkEdge):
         start: NetworkNode,
         end: NetworkNode,
         length: float,
-        breakpoints: list[EdgeBreakPoint] | None = None,
+        breakpoints: list[ReachBreakPoint] | None = None,
     ) -> None:
         self._id = id
         self._start = start
         self._end = end
         self._length = length
-        self._breakpoints: list[EdgeBreakPoint] = breakpoints or []
+        self._breakpoints: list[ReachBreakPoint] = breakpoints or []
 
     @property
     def id(self) -> str:
@@ -319,17 +319,17 @@ class BasicEdge(NetworkEdge):
         return self._length
 
     @property
-    def breakpoints(self) -> list[EdgeBreakPoint]:
+    def breakpoints(self) -> list[ReachBreakPoint]:
         return self._breakpoints
 
 
 class Network:
-    """Network built from a set of edges, with coordinate lookup and data access."""
+    """Network built from a set of reaches, with coordinate lookup and data access."""
 
-    def __init__(self, edges: Sequence[NetworkEdge]):
-        graph = self._generate_graph(edges)
+    def __init__(self, reaches: Sequence[NetworkReach]):
+        graph = self._generate_graph(reaches)
         self._initialize_network_attributes(graph)
-        self._edges = self._generate_edges_dict(edges)
+        self._reaches = self._generate_reaches_dict(reaches)
 
     def _initialize_network_attributes(self, graph: nx.Graph):
         self._alias_map = self._generate_alias_map(graph)
@@ -341,7 +341,7 @@ class Network:
         time_window = "N/A - N/A" if len(time) == 0 else f"{time[0]} - {time[-1]}"
         out = [
             "<Network>",
-            f"Edges: {len(self._edges)}",
+            f"Reaches: {len(self._reaches)}",
             f"Nodes: {self._graph.number_of_nodes()}",
             f"Quantities: {self.quantities}",
             f"Time: {time_window}",
@@ -445,7 +445,6 @@ class Network:
 
         list_of_reaches = cls._load_res1d_network(res, nodes_list, reaches_list)
         return cls(list_of_reaches)
-
     @staticmethod
     def _load_res1d_network(
         res: Res1D,
@@ -492,8 +491,8 @@ class Network:
         return {g.nodes[id]["alias"]: id for id in g.nodes()}
 
     @staticmethod
-    def _generate_edges_dict(edges: Sequence[NetworkEdge]) -> dict[str, NetworkEdge]:
-        return {e.id: e for e in edges}
+    def _generate_reaches_dict(reaches: Sequence[NetworkReach]) -> dict[str, NetworkReach]:
+        return {r.id: r for r in reaches}
 
     @staticmethod
     def _build_dataframe(g: nx.Graph) -> pd.DataFrame:
@@ -564,11 +563,11 @@ class Network:
         return list(self.to_dataframe().columns.get_level_values(1).unique())
 
     @staticmethod
-    def _generate_graph(edges: Sequence[NetworkEdge]) -> nx.Graph:
+    def _generate_graph(reaches: Sequence[NetworkReach]) -> nx.Graph:
         g0 = nx.Graph()
-        for edge in edges:
+        for reach in reaches:
             # 1) Add start and end nodes
-            for node in [edge.start, edge.end]:
+            for node in [reach.start, reach.end]:
                 node_key = node.id
                 if node_key in g0.nodes:
                     g0.nodes[node_key]["boundary"].update(node.boundary)
@@ -576,26 +575,26 @@ class Network:
                     g0.add_node(node_key, data=node.data, boundary=node.boundary)
 
             # 2) Add edges connecting start/end nodes to their adjacent breakpoints
-            start_key = edge.start.id
-            end_key = edge.end.id
-            if edge.n_breakpoints == 0:
-                g0.add_edge(start_key, end_key, length=edge.length)
+            start_key = reach.start.id
+            end_key = reach.end.id
+            if reach.n_breakpoints == 0:
+                g0.add_edge(start_key, end_key, length=reach.length)
             else:
-                bp_keys = [bp.id for bp in edge.breakpoints]
-                for bp, bp_key in zip(edge.breakpoints, bp_keys):
+                bp_keys = [bp.id for bp in reach.breakpoints]
+                for bp, bp_key in zip(reach.breakpoints, bp_keys):
                     g0.add_node(bp_key, data=bp.data)
 
-                g0.add_edge(start_key, bp_keys[0], length=edge.breakpoints[0].distance)
+                g0.add_edge(start_key, bp_keys[0], length=reach.breakpoints[0].distance)
                 g0.add_edge(
                     bp_keys[-1],
                     end_key,
-                    length=edge.length - edge.breakpoints[-1].distance,
+                    length=reach.length - reach.breakpoints[-1].distance,
                 )
 
             # 3) Connect consecutive intermediate breakpoints
-            for i in range(edge.n_breakpoints - 1):
-                current_ = edge.breakpoints[i]
-                next_ = edge.breakpoints[i + 1]
+            for i in range(reach.n_breakpoints - 1):
+                current_ = reach.breakpoints[i]
+                next_ = reach.breakpoints[i + 1]
                 length = next_.distance - current_.distance
                 g0.add_edge(
                     current_.id,
@@ -610,7 +609,7 @@ class Network:
         self,
         *,
         node: str,
-        edge: None = None,
+        reach: None = None,
         distance: None = None,
     ) -> int:
         pass
@@ -620,7 +619,7 @@ class Network:
         self,
         *,
         node: list[str],
-        edge: None = None,
+        reach: None = None,
         distance: None = None,
     ) -> list[int]:
         pass
@@ -630,7 +629,7 @@ class Network:
         self,
         *,
         node: None = None,
-        edge: str | list[str],
+        reach: str | list[str],
         distance: str | float,
     ) -> int:
         pass
@@ -640,7 +639,7 @@ class Network:
         self,
         *,
         node: None = None,
-        edge: str | list[str],
+        reach: str | list[str],
         distance: list[str | float],
     ) -> list[int]:
         pass
@@ -648,7 +647,7 @@ class Network:
     def find(
         self,
         node: str | list[str] | None = None,
-        edge: str | list[str] | None = None,
+        reach: str | list[str] | None = None,
         distance: str | float | list[str | float] | None = None,
     ) -> int | list[int]:
         """Find node or breakpoint id in the Network object based on former coordinates.
@@ -657,11 +656,11 @@ class Network:
         ----------
         node : str | List[str], optional
             Node id(s) in the original network, by default None
-        edge : str | List[str], optional
-            Edge id(s) for breakpoint lookup or edge endpoint lookup, by default None
+        reach : str | List[str], optional
+            Reach id(s) for breakpoint lookup or reach endpoint lookup, by default None
         distance : str | float | List[str | float], optional
-            Distance(s) along edge for breakpoint lookup, or "start"/"end"
-            for edge endpoints, by default None
+            Distance(s) along reach for breakpoint lookup, or "start"/"end"
+            for reach endpoints, by default None
 
         Returns
         -------
@@ -676,16 +675,16 @@ class Network:
             If requested node/breakpoint is not found in the network
         """
         by_node = node is not None
-        by_breakpoint = edge is not None or distance is not None
+        by_breakpoint = reach is not None or distance is not None
 
         if by_node and by_breakpoint:
             raise ValueError(
-                "Cannot specify both 'node' and 'edge'/'distance' parameters simultaneously"
+                "Cannot specify both 'node' and 'reach'/'distance' parameters simultaneously"
             )
 
         if not by_node and not by_breakpoint:
             raise ValueError(
-                "Must specify either 'node' or both 'edge' and 'distance' parameters"
+                "Must specify either 'node' or both 'reach' and 'distance' parameters"
             )
 
         ids: list[str | tuple[str, float]]
@@ -697,43 +696,43 @@ class Network:
             ids = list(node)
 
         else:
-            if edge is None or distance is None:
+            if reach is None or distance is None:
                 raise ValueError(
-                    "Both 'edge' and 'distance' parameters are required for breakpoint/endpoint lookup"
+                    "Both 'reach' and 'distance' parameters are required for breakpoint/endpoint lookup"
                 )
 
-            if not isinstance(edge, list):
-                edge = [edge]
+            if not isinstance(reach, list):
+                reach = [reach]
 
             if not isinstance(distance, list):
                 distance = [distance]
 
-            if len(edge) == 1:
-                edge = edge * len(distance)
+            if len(reach) == 1:
+                reach = reach * len(distance)
 
-            if len(edge) != len(distance):
+            if len(reach) != len(distance):
                 raise ValueError(
-                    "Incompatible lengths of 'edge' and 'distance' arguments. One 'edge' admits multiple distances, otherwise they must be the same length."
+                    "Incompatible lengths of 'reach' and 'distance' arguments. One 'reach' admits multiple distances, otherwise they must be the same length."
                 )
 
             ids = []
-            for edge_i, distance_i in zip(edge, distance):
+            for reach_i, distance_i in zip(reach, distance):
                 if distance_i in ["start", "end"]:
-                    if edge_i not in self._edges:
-                        raise KeyError(f"Edge '{edge_i}' not found in the network.")
+                    if reach_i not in self._reaches:
+                        raise KeyError(f"Reach '{reach_i}' not found in the network.")
 
-                    network_edge = self._edges[edge_i]
+                    network_reach = self._reaches[reach_i]
                     if distance_i == "start":
-                        ids.append(network_edge.start.id)
+                        ids.append(network_reach.start.id)
                     else:
-                        ids.append(network_edge.end.id)
+                        ids.append(network_reach.end.id)
                 else:
                     if not isinstance(distance_i, (int, float)):
                         raise ValueError(
                             "Invalid 'distance' value for breakpoint lookup: "
                             f"{distance_i!r}. Expected a numeric value or 'start'/'end'."
                         )
-                    ids.append((edge_i, distance_i))
+                    ids.append((reach_i, distance_i))
 
         _CHAINAGE_TOLERANCE = 1e-3
 
@@ -741,11 +740,11 @@ class Network:
             if id in self._alias_map:
                 return self._alias_map[id]
             if isinstance(id, tuple):
-                edge_id, distance = id
+                reach_id, distance = id
                 for key, val in self._alias_map.items():
                     if (
                         isinstance(key, tuple)
-                        and key[0] == edge_id
+                        and key[0] == reach_id
                         and abs(key[1] - distance) <= _CHAINAGE_TOLERANCE
                     ):
                         return val
@@ -783,7 +782,7 @@ class Network:
             Original coordinates. For single input returns dict, for multiple inputs returns list of dicts.
             Dict contains coordinates:
             - For nodes: 'node' key with node id
-            - For breakpoints: 'edge' and 'distance' keys with edge id and distance
+            - For breakpoints: 'reach' and 'distance' keys with reach id and distance
 
         Raises
         ------
@@ -806,7 +805,7 @@ class Network:
             if isinstance(key, str):
                 results.append({"node": key})
             else:
-                results.append({"edge": key[0], "distance": key[1]})
+                results.append({"reach": key[0], "distance": key[1]})
 
         if len(results) == 1:
             return results[0]
@@ -829,8 +828,8 @@ def _make_basic_network(node_ids, time, data, quantity="WaterLevel"):
         BasicNode(nid, pd.DataFrame({quantity: data[:, i]}, index=time))
         for i, nid in enumerate(node_ids)
     ]
-    edges = [
-        BasicEdge(f"e{i}", nodes[i], nodes[i + 1], length=100.0)
+    reaches = [
+        BasicReach(f"r{i}", nodes[i], nodes[i + 1], length=100.0)
         for i in range(len(nodes) - 1)
     ]
-    return Network(edges)
+    return Network(reaches)

--- a/src/modelskill/obs.py
+++ b/src/modelskill/obs.py
@@ -36,9 +36,9 @@ Serializable = Union[str, int, float]
 def observation(
     data: DataInputType,
     *,
-    gtype: Literal["point", "track", "node", "edge"] | None = None,
+    gtype: Literal["point", "track", "node", "reach"] | None = None,
     **kwargs,
-) -> PointObservation | TrackObservation | NodeObservation | EdgeObservation:
+) -> PointObservation | TrackObservation | NodeObservation | ReachObservation:
     """Create an appropriate observation object.
 
     A factory function for creating an appropriate observation object
@@ -47,20 +47,20 @@ def observation(
     If 'x' or 'y' is given, a PointObservation is created.
     If 'x_item' or 'y_item' is given, a TrackObservation is created.
     If 'node' is given, a NodeObservation is created.
-    If 'edge' is given (without 'distance'), an EdgeObservation is created.
+    If 'reach' is given (without 'distance'), a ReachObservation is created.
 
     Parameters
     ----------
     data : DataInputType
         The data to be used for creating the Observation object.
-    gtype : Literal["point", "track", "node", "edge"] | None
+    gtype : Literal["point", "track", "node", "reach"] | None
         The geometry type of the data. If not specified, it will be guessed from the data.
     **kwargs
         Additional keyword arguments to be passed to the Observation constructor.
 
     Returns
     -------
-    PointObservation or TrackObservation or NodeObservation or EdgeObservation
+    PointObservation or TrackObservation or NodeObservation or ReachObservation
         An observation object of the appropriate type
 
     Examples
@@ -69,19 +69,19 @@ def observation(
     >>> o_pt = ms.observation(df, item=0, x=366844, y=6154291, name="Klagshamn")
     >>> o_tr = ms.observation("lon_after_lat.dfs0", item="wl", x_item=1, y_item=0)
     >>> o_node = ms.observation(df, item="Water Level", node=123, name="123")
-    >>> o_edge = ms.observation(df, item="Discharge", edge="reach_1", name="reach_1_Q")
+    >>> o_reach = ms.observation(df, item="Discharge", reach="reach_1", name="reach_1_Q")
     """
-    # EdgeObservation is handled directly since it shares the NODE gtype internally.
-    # If both edge and distance are provided, this represents a network location
-    # along an edge and should be treated as a NodeObservation via at=(edge, distance).
-    if gtype == "edge" or (gtype is None and "edge" in kwargs):
+    # ReachObservation is handled directly since it shares the NODE gtype internally.
+    # If both reach and distance are provided, this represents a network location
+    # along a reach and should be treated as a NodeObservation via at=(reach, distance).
+    if gtype == "reach" or (gtype is None and "reach" in kwargs):
         if "distance" in kwargs:
             node_kwargs = dict(kwargs)
-            edge = node_kwargs.pop("edge")
+            reach = node_kwargs.pop("reach")
             distance = node_kwargs.pop("distance")
-            node_kwargs["at"] = (edge, distance)
+            node_kwargs["at"] = (reach, distance)
             return NodeObservation(data=data, **node_kwargs)
-        return EdgeObservation(data=data, **kwargs)
+        return ReachObservation(data=data, **kwargs)
 
     if gtype is None:
         geometry = _guess_gtype(**kwargs)
@@ -105,7 +105,7 @@ def _guess_gtype(**kwargs) -> GeometryType:
         return GeometryType.NODE
     else:
         warnings.warn(
-            "Could not guess geometry type from data or args, assuming POINT geometry. Use PointObservation, TrackObservation, NodeObservation, or EdgeObservation to be explicit."
+            "Could not guess geometry type from data or args, assuming POINT geometry. Use PointObservation, TrackObservation, NodeObservation, or ReachObservation to be explicit."
         )
         return GeometryType.POINT
 
@@ -371,7 +371,7 @@ class NodeObservation(Observation):
     (e.g. the original Res1D node name). String aliases are resolved to
     integer IDs automatically when matched against a
     :class:`~modelskill.model.network.NetworkModelResult`.
-    For breakpoint locations (edge + distance), use the ``at`` parameter.
+    For breakpoint locations (reach + distance), use the ``at`` parameter.
 
     To create multiple NodeObservation objects from a single data source,
     use :method:`from_multiple`.
@@ -389,7 +389,7 @@ class NodeObservation(Observation):
 
         Mutually exclusive with ``at``.
     at : tuple[str, float], optional
-        Breakpoint location as ``(edge_id, distance)`` along an edge, resolved
+        Breakpoint location as ``(reach_id, distance)`` along a reach, resolved
         via the alias map when matched against a
         :class:`~modelskill.model.network.NetworkModelResult`.
         Mutually exclusive with ``node``.
@@ -415,7 +415,7 @@ class NodeObservation(Observation):
     >>>
     >>> o3 = ms.NodeObservation(data, node="node_A")
     >>>
-    >>> # Breakpoint as (edge_id, distance) tuple
+    >>> # Breakpoint as (reach_id, distance) tuple
     >>> o4 = ms.NodeObservation(data, at=("reach_1", 24.5))
     >>>
     >>> # Multiple node observations from separate data sources
@@ -440,7 +440,7 @@ class NodeObservation(Observation):
         if node is None and at is None:
             raise ValueError("Either 'node' or 'at' must be provided.")
         if at is not None:
-            edge, distance = str(at[0]), float(at[1])
+            reach, distance = str(at[0]), float(at[1])
             if not self._is_input_validated(data):
                 data = _parse_network_breakpoint_input(
                     data,
@@ -448,7 +448,7 @@ class NodeObservation(Observation):
                     item=item,
                     quantity=quantity,
                     aux_items=aux_items,
-                    edge=edge,
+                    reach=reach,
                     distance=distance,
                 )
         else:
@@ -467,27 +467,27 @@ class NodeObservation(Observation):
     @property
     def node(self) -> int | str | None:
         """Node ID of observation, or ``None`` if this is a breakpoint observation (use ``at`` instead)."""
-        if "edge" in self.data.coords:
+        if "reach" in self.data.coords:
             return None
         return self.data.coords["node"].item()  # int or str
 
     @property
     def at(self) -> tuple[str, float] | None:
-        """Breakpoint location as ``(edge_id, distance)``, or ``None`` if this is a node observation (use ``node`` instead)."""
-        if "edge" in self.data.coords:
+        """Breakpoint location as ``(reach_id, distance)``, or ``None`` if this is a node observation (use ``node`` instead)."""
+        if "reach" in self.data.coords:
             return (
-                str(self.data.coords["edge"].item()),
+                str(self.data.coords["reach"].item()),
                 float(self.data.coords["distance"].item()),
             )
         return None
 
     def _create_new_instance(self, data: xr.Dataset) -> Self:
         """Reconstruct instance from a dataset slice."""
-        if "edge" in data.coords:
+        if "reach" in data.coords:
             return self.__class__(
                 data,
                 at=(
-                    str(data.coords["edge"].item()),
+                    str(data.coords["reach"].item()),
                     float(data.coords["distance"].item()),
                 ),
             )
@@ -597,22 +597,22 @@ class NodeObservation(Observation):
             ]
 
 
-class EdgeObservation(Observation):
-    """Class for observations representing a quantity uniform across a network edge.
+class ReachObservation(Observation):
+    """Class for observations representing a quantity uniform across a network reach.
 
     Some quantities (e.g. discharge in a river reach) are constant for the
-    whole edge, even though the underlying model stores values at
-    nodes/breakpoints.  An EdgeObservation associates a timeseries with a
-    named edge; when matched against a
+    whole reach, even though the underlying model stores values at
+    nodes/breakpoints.  A ReachObservation associates a timeseries with a
+    named reach; when matched against a
     :class:`~modelskill.model.network.NetworkModelResult` the data is
-    extracted from an arbitrary breakpoint that belongs to that edge.
+    extracted from an arbitrary breakpoint that belongs to that reach.
 
     Parameters
     ----------
     data : str, Path, mikeio.Dataset, mikeio.DataArray, pd.DataFrame, pd.Series, xr.Dataset or xr.DataArray
-        data source with time series for the edge quantity
-    edge : str
-        Edge identifier (reach name / edge ID) in the network.
+        data source with time series for the reach quantity
+    reach : str
+        Reach identifier (reach name / reach ID) in the network.
     item : (int, str), optional
         index or name of the wanted item/column, by default None
         if data contains more than one item, item must be given
@@ -630,14 +630,14 @@ class EdgeObservation(Observation):
     Examples
     --------
     >>> import modelskill as ms
-    >>> o1 = ms.EdgeObservation(df, edge="reach_1", name="Q_reach_1")
-    >>> o2 = ms.EdgeObservation(df, item="Discharge", edge="reach_2")
+    >>> o1 = ms.ReachObservation(df, reach="reach_1", name="Q_reach_1")
+    >>> o2 = ms.ReachObservation(df, item="Discharge", reach="reach_2")
     """
 
     def __init__(
         self,
         data: PointType,
-        edge: str,
+        reach: str,
         *,
         item: int | str | None = None,
         name: str | None = None,
@@ -653,20 +653,20 @@ class EdgeObservation(Observation):
                 item=item,
                 quantity=quantity,
                 aux_items=aux_items,
-                edge=edge,
+                reach=reach,
                 distance=None,
             )
         assert isinstance(data, xr.Dataset)
         super().__init__(data=data, weight=weight, attrs=attrs)
 
     @property
-    def edge(self) -> str:
-        """Edge ID of this observation."""
-        return str(self.data.coords["edge"].item())
+    def reach(self) -> str:
+        """Reach ID of this observation."""
+        return str(self.data.coords["reach"].item())
 
     def _create_new_instance(self, data: xr.Dataset) -> Self:
         """Reconstruct instance from a dataset slice."""
-        return self.__class__(data, edge=str(data.coords["edge"].item()))
+        return self.__class__(data, reach=str(data.coords["reach"].item()))
 
 
 def unit_display_name(name: str) -> str:

--- a/src/modelskill/timeseries/_coords.py
+++ b/src/modelskill/timeseries/_coords.py
@@ -26,26 +26,26 @@ class NodeCoords:
         return {"node": self.node}
 
 
-class EdgeCoords:
-    """Coordinates for an observation along a network edge.
+class ReachCoords:
+    """Coordinates for an observation along a network reach.
 
     Parameters
     ----------
-    edge : str
-        Edge (reach) identifier.
+    reach : str
+        Reach identifier.
     distance : float or None, optional
-        Along-edge distance (chainage).  When ``None`` the observation is
-        edge-level (no specific chainage) and no ``distance`` coordinate is
+        Along-reach distance (chainage).  When ``None`` the observation is
+        reach-level (no specific chainage) and no ``distance`` coordinate is
         stored in the dataset.
     """
 
-    def __init__(self, edge: str, distance: float | None = None):
-        self.edge = edge
+    def __init__(self, reach: str, distance: float | None = None):
+        self.reach = reach
         self.distance = distance
 
     @property
     def as_dict(self) -> dict:
-        d: dict = {"edge": self.edge}
+        d: dict = {"reach": self.reach}
         if self.distance is not None:
             d["distance"] = self.distance
         return d

--- a/src/modelskill/timeseries/_point.py
+++ b/src/modelskill/timeseries/_point.py
@@ -243,7 +243,7 @@ def _parse_point_input(
     quantity: Quantity | None,
     aux_items: Sequence[int | str] | None,
     *,
-    coords: XYZCoords | NodeCoords | EdgeCoords,
+    coords: XYZCoords | NodeCoords | ReachCoords,
 ) -> xr.Dataset:
     """Convert accepted input data to an xr.Dataset."""
 

--- a/src/modelskill/timeseries/_point.py
+++ b/src/modelskill/timeseries/_point.py
@@ -12,7 +12,7 @@ from ..types import GeometryType, PointType
 from ..quantity import Quantity
 from ..utils import _get_name
 from ._timeseries import _validate_data_var_name
-from ._coords import XYZCoords, NodeCoords, EdgeCoords
+from ._coords import XYZCoords, NodeCoords, ReachCoords
 
 
 @dataclass
@@ -143,7 +143,7 @@ def _convert_to_dataset(
 def _include_coords(
     ds: xr.Dataset,
     *,
-    coords: XYZCoords | NodeCoords | EdgeCoords | None = None,
+    coords: XYZCoords | NodeCoords | ReachCoords | None = None,
 ) -> xr.Dataset:
     ds = ds.copy()
     if coords is not None:
@@ -166,7 +166,7 @@ def _include_attributes(
 ) -> xr.Dataset:
     ds = ds.copy()
 
-    if "node" in ds.coords or "edge" in ds.coords:
+    if "node" in ds.coords or "reach" in ds.coords:
         ds.attrs["gtype"] = str(GeometryType.NODE)
     else:
         ds.attrs["gtype"] = str(GeometryType.POINT)
@@ -299,15 +299,15 @@ def _parse_network_breakpoint_input(
     quantity: Quantity | None,
     aux_items: Sequence[int | str] | None,
     *,
-    edge: str,
+    reach: str,
     distance: float | None = None,
 ) -> xr.Dataset:
-    """Parse input for a breakpoint (or edge-level) observation.
+    """Parse input for a breakpoint (or reach-level) observation.
 
-    When ``distance`` is ``None`` the observation is edge-level — no
+    When ``distance`` is ``None`` the observation is reach-level — no
     ``distance`` coordinate is stored and the result can be matched to any
-    breakpoint on the edge.
+    breakpoint on the reach.
     """
-    coords = EdgeCoords(edge=edge, distance=distance)
+    coords = ReachCoords(reach=reach, distance=distance)
     ds = _parse_point_input(data, name, item, quantity, aux_items, coords=coords)
     return ds

--- a/src/modelskill/timeseries/_timeseries.py
+++ b/src/modelskill/timeseries/_timeseries.py
@@ -63,21 +63,21 @@ def _validate_dataset(ds: xr.Dataset) -> xr.Dataset:
         ds.time.to_index().is_monotonic_increasing
     ), "time must be increasing (please check for duplicate times))"
 
-    # Validate coordinates: x,y spatial, node-based, or edge-based (with or without chainage)
+    # Validate coordinates: x,y spatial, node-based, or reach-based (with or without chainage)
     has_spatial_coords = "x" in ds.coords and "y" in ds.coords
     has_node_coord = "node" in ds.coords
-    has_breakpoint_coords = "edge" in ds.coords and "distance" in ds.coords
-    has_edge_coord = "edge" in ds.coords and "distance" not in ds.coords
+    has_breakpoint_coords = "reach" in ds.coords and "distance" in ds.coords
+    has_reach_coord = "reach" in ds.coords and "distance" not in ds.coords
 
     if (
         not has_spatial_coords
         and not has_node_coord
         and not has_breakpoint_coords
-        and not has_edge_coord
+        and not has_reach_coord
     ):
         raise ValueError(
             "data must have either x,y coordinates, a node coordinate, "
-            "edge+distance coordinates, or an edge coordinate"
+            "reach+distance coordinates, or a reach coordinate"
         )
 
     if has_spatial_coords:

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -783,7 +783,7 @@ def test_network_match_multi_obs_multi_model_comprehensive(
 def test_network_match_error_non_node_observation(network_mr, point_obs_error):
     """Test that non-NodeObservation raises appropriate error"""
     with pytest.raises(
-        TypeError, match="NetworkModelResult supports NodeObservation and EdgeObservation"
+        TypeError, match="NetworkModelResult supports NodeObservation and ReachObservation"
     ):
         ms.match(point_obs_error, network_mr)
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -17,7 +17,7 @@ from modelskill.model.network import (
 from modelskill.network import (
     Network,
     BasicNode,
-    BasicEdge,
+    BasicReach,
 )
 from modelskill.obs import NodeObservation
 from modelskill.quantity import Quantity
@@ -28,11 +28,11 @@ def _make_network(node_ids, time, data, quantity="WaterLevel"):
         BasicNode(nid, pd.DataFrame({quantity: data[:, i]}, index=time))
         for i, nid in enumerate(node_ids)
     ]
-    edges = [
-        BasicEdge(f"e{i}", nodes[i], nodes[i + 1], length=100.0)
+    reaches = [
+        BasicReach(f"r{i}", nodes[i], nodes[i + 1], length=100.0)
         for i in range(len(nodes) - 1)
     ]
-    return Network(edges)
+    return Network(reaches)
 
 
 @pytest.fixture
@@ -85,7 +85,7 @@ def sample_network_multivars():
         )
         for i, nid in enumerate(["123", "456"])
     ]
-    edges = [BasicEdge("e1", nodes[0], nodes[1], length=100.0)]
+    edges = [BasicReach("r1", nodes[0], nodes[1], length=100.0)]
     return Network(edges)
 
 
@@ -200,7 +200,7 @@ class TestNetworkModelResult:
         obs = ms.PointObservation(df, x=0.0, y=0.0)
 
         with pytest.raises(
-            TypeError, match="NetworkModelResult supports NodeObservation and EdgeObservation"
+            TypeError, match="NetworkModelResult supports NodeObservation and ReachObservation"
         ):
             nmr.extract(obs)
 
@@ -454,7 +454,7 @@ def test_extract_edge_observation_happy_path(sample_node_data):
     network = Network.from_res1d(path_to_file)
     nmr = NetworkModelResult(network, item="Discharge", name="network_model")
     obs_data = sample_node_data.rename(columns={"WaterLevel": "Discharge"})
-    obs = ms.EdgeObservation(obs_data, edge="100l1", item="Discharge")
+    obs = ms.ReachObservation(obs_data, reach="100l1", item="Discharge")
 
     extracted = nmr.extract(obs)
 
@@ -471,7 +471,7 @@ def test_extract_edge_observation_non_equivalent_breakpoints_raises(sample_node_
     network = Network.from_res1d(path_to_file)
     nmr = NetworkModelResult(network, item="Discharge")
     obs_data = sample_node_data.rename(columns={"WaterLevel": "Discharge"})
-    obs = ms.EdgeObservation(obs_data, edge="113l1", item="Discharge")
+    obs = ms.ReachObservation(obs_data, reach="113l1", item="Discharge")
 
     with pytest.raises(
         ValueError, match="Not all data in breakpoints are equivalent"
@@ -488,7 +488,7 @@ def test_extract_edge_observation_with_reaches_not_populated_raises_valueerror(
     path_to_file = "./tests/testdata/network.res1d"
     network = Network.from_res1d(path_to_file, reaches=[])
     nmr = NetworkModelResult(network, item="WaterLevel")
-    obs = ms.EdgeObservation(sample_node_data, edge="100l1", item="WaterLevel")
+    obs = ms.ReachObservation(sample_node_data, reach="100l1", item="WaterLevel")
 
     with pytest.raises(ValueError, match="none of its breakpoints have data loaded"):
         nmr.extract(obs)
@@ -504,7 +504,7 @@ def test_extract_edge_observation_breakpoint_node_missing_raises_valueerror(
     network = Network.from_res1d(path_to_file)
     nmr = NetworkModelResult(network, item="Discharge")
     obs_data = sample_node_data.rename(columns={"WaterLevel": "Discharge"})
-    baseline_obs = ms.EdgeObservation(obs_data, edge="100l1", item="Discharge")
+    baseline_obs = ms.ReachObservation(obs_data, reach="100l1", item="Discharge")
     node_id = nmr.extract(baseline_obs).node
     remaining_nodes = []
     for node in nmr.data.node.values:
@@ -513,7 +513,7 @@ def test_extract_edge_observation_breakpoint_node_missing_raises_valueerror(
             remaining_nodes.append(node_int)
     nmr.data = nmr.data.sel(node=remaining_nodes)
 
-    obs = ms.EdgeObservation(obs_data, edge="100l1", item="Discharge")
+    obs = ms.ReachObservation(obs_data, reach="100l1", item="Discharge")
 
     with pytest.raises(ValueError, match="matching breakpoint nodes are missing"):
         nmr.extract(obs)
@@ -611,7 +611,7 @@ def test_from_res1d_empty_nodes_and_reaches_keeps_topology_and_empty_outputs():
 
 
 class TestNodeObservationAliases:
-    """NodeObservation accepts int, str alias, and (edge, distance) tuple."""
+    """NodeObservation accepts int, str alias, and (reach, distance) tuple."""
 
     def test_integer_node_unchanged(self, sample_node_data):
         obs = NodeObservation(sample_node_data, node=42)
@@ -647,11 +647,11 @@ class TestNodeObservationAliases:
         obs = NodeObservation(sample_node_data, at=("reach_1", 24.5))
         assert obs.data.attrs["gtype"] == "node"
 
-    def test_tuple_node_has_edge_distance_coords(self, sample_node_data):
+    def test_tuple_node_has_reach_distance_coords(self, sample_node_data):
         obs = NodeObservation(sample_node_data, at=("reach_1", 24.5))
-        assert "edge" in obs.data.coords
+        assert "reach" in obs.data.coords
         assert "distance" in obs.data.coords
-        assert str(obs.data.coords["edge"].item()) == "reach_1"
+        assert str(obs.data.coords["reach"].item()) == "reach_1"
         assert float(obs.data.coords["distance"].item()) == pytest.approx(24.5)
 
     def test_tuple_node_has_no_node_coord(self, sample_node_data):
@@ -775,7 +775,7 @@ class TestNetworkModelResultAliasResolution:
         self, sample_network, sample_node_data
     ):
         nmr = NetworkModelResult(sample_network)
-        obs = NodeObservation(sample_node_data, at=("nonexistent_edge", 0.0))
+        obs = NodeObservation(sample_node_data, at=("nonexistent_reach", 0.0))
         with pytest.raises(ValueError, match="not found"):
             nmr.extract(obs)
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -85,8 +85,8 @@ def sample_network_multivars():
         )
         for i, nid in enumerate(["123", "456"])
     ]
-    edges = [BasicReach("r1", nodes[0], nodes[1], length=100.0)]
-    return Network(edges)
+    reaches = [BasicReach("r1", nodes[0], nodes[1], length=100.0)]
+    return Network(reaches)
 
 
 @pytest.fixture
@@ -449,7 +449,7 @@ def test_open_res1d():
 @pytest.mark.skipif(
     sys.version_info >= (3, 14), reason="mikeio1d requires Python < 3.14"
 )
-def test_extract_edge_observation_happy_path(sample_node_data):
+def test_extract_reach_observation_happy_path(sample_node_data):
     path_to_file = "./tests/testdata/network.res1d"
     network = Network.from_res1d(path_to_file)
     nmr = NetworkModelResult(network, item="Discharge", name="network_model")
@@ -466,7 +466,7 @@ def test_extract_edge_observation_happy_path(sample_node_data):
 @pytest.mark.skipif(
     sys.version_info >= (3, 14), reason="mikeio1d requires Python < 3.14"
 )
-def test_extract_edge_observation_non_equivalent_breakpoints_raises(sample_node_data):
+def test_extract_reach_observation_non_equivalent_breakpoints_raises(sample_node_data):
     path_to_file = "./tests/testdata/network.res1d"
     network = Network.from_res1d(path_to_file)
     nmr = NetworkModelResult(network, item="Discharge")
@@ -482,7 +482,7 @@ def test_extract_edge_observation_non_equivalent_breakpoints_raises(sample_node_
 @pytest.mark.skipif(
     sys.version_info >= (3, 14), reason="mikeio1d requires Python < 3.14"
 )
-def test_extract_edge_observation_with_reaches_not_populated_raises_valueerror(
+def test_extract_reach_observation_with_reaches_not_populated_raises_valueerror(
     sample_node_data,
 ):
     path_to_file = "./tests/testdata/network.res1d"
@@ -497,7 +497,7 @@ def test_extract_edge_observation_with_reaches_not_populated_raises_valueerror(
 @pytest.mark.skipif(
     sys.version_info >= (3, 14), reason="mikeio1d requires Python < 3.14"
 )
-def test_extract_edge_observation_breakpoint_node_missing_raises_valueerror(
+def test_extract_reach_observation_breakpoint_node_missing_raises_valueerror(
     sample_node_data,
 ):
     path_to_file = "./tests/testdata/network.res1d"


### PR DESCRIPTION
Closes #641
 
 ## Summary
 
 Renames all network-related "edge" terminology to "reach" to align with DHI nomenclature.
 
 ## Class renames
 - `EdgeBreakPoint` → `ReachBreakPoint`
 - `NetworkEdge` → `NetworkReach`
 - `BasicEdge` → `BasicReach`
 - `EdgeObservation` → `ReachObservation`
 - `EdgeCoords` → `ReachCoords` (internal timeseries layer)
 
 ## API changes
 - `Network(edges=...)` → `Network(reaches=...)`
 - `Network.find(edge=...)` → `Network.find(reach=...)`
 - `Network.recall()` return dict: `'edge'` key → `'reach'` key
 - `observation(gtype='edge')` → `observation(gtype='reach')`
 - xarray coordinate `'edge'` → `'reach'` in datasets
 - `NetworkModelResult._extract_edge()` → `_extract_reach()`
 
 ## Files updated
 - `src/modelskill/network.py`
 - `src/modelskill/obs.py`
 - `src/modelskill/model/network.py`
 - `src/modelskill/model/adapters/_res1d.py`
 - `src/modelskill/timeseries/_coords.py`
 - `src/modelskill/timeseries/_point.py`
 - `src/modelskill/timeseries/_timeseries.py`
 - `src/modelskill/__init__.py`
 - `src/modelskill/matching.py`
 - `tests/test_network.py`
 - `tests/test_match.py`
 - `docs/user-guide/network.qmd`
 - `docs/_quarto.yml`
 
 All 652 tests pass.