### PR TITLE
Scatter Plot Convention Update

### DIFF
--- a/src/modelskill/styles/mood.yml
+++ b/src/modelskill/styles/mood.yml
@@ -19,7 +19,7 @@ plot.scatter.points.alpha: 0.9
 plot.scatter.points.label: Data
 plot.scatter.points.size: 10.0
 plot.scatter.quantiles.color: [0,0,0,0]
-plot.scatter.quantiles.label: Quantiles (0.0 - 100.0%)
+plot.scatter.quantiles.label: Quantiles (0.0 - 1.0)
 plot.scatter.quantiles.marker: o
 plot.scatter.quantiles.markeredgecolor: [0, 0.596078431372549, 0.8588235294117647]
 plot.scatter.quantiles.markeredgewidth: 1.2


### PR DESCRIPTION
* A convention issue was observed regarding the QQ points in the scatter plot - see below:
<img width="986" height="639" alt="image" src="https://github.com/user-attachments/assets/d9304cbf-0529-4ddc-b506-3cfbc073dded" />

* Quantiles should be 0.0 - 1.0, whereas it was confused with percentiles.
* The mood.yml file is updated accordinly
* New adjustment looks like this:
<img width="1015" height="678" alt="image" src="https://github.com/user-attachments/assets/e3804793-615b-46b4-a71a-9e87150af59d" />
