### PR TITLE
fix: convert 3D geometry to 2D in spatial_overview

### DIFF
--- a/src/modelskill/plotting/_spatial_overview.py
+++ b/src/modelskill/plotting/_spatial_overview.py
@@ -80,6 +80,10 @@ def spatial_overview(
         else:
             g = m
 
+        # mikeio's 3D geometries (GeometryFM3D) cannot be plotted directly
+        if hasattr(g, "to_2d_geometry"):
+            g = g.to_2d_geometry()
+
             # TODO this is not supported for all model types
         g.plot.outline(ax=ax)  # type: ignore
 


### PR DESCRIPTION
mikeio's `GeometryFM3D.plot` was made strict and now raises `AttributeError: ... Use .to_2d_geometry().plot instead.`, which broke `notebooks/vertical_skill.ipynb` on main (Notebooks test on e528570b).

This patch flattens the geometry via duck-typed `to_2d_geometry()` before drawing the outline.

Follow-up cleanup of the wider `spatial_overview` function tracked separately.