### PR TITLE
docs: surface vertical API in reference

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -83,6 +83,7 @@ website:
             - api/TrackObservation.qmd
             - api/NodeObservation.qmd
             - api/ReachObservation.qmd
+            - api/VerticalObservation.qmd
         - section: "Model Result"
           href: api/model.qmd
           contents:
@@ -93,6 +94,7 @@ website:
             - api/GridModelResult.qmd
             - api/DummyModelResult.qmd
             - api/NetworkModelResult.qmd
+            - api/VerticalModelResult.qmd
         - section: "Matching"
           contents:
             - api/match.qmd
@@ -106,9 +108,13 @@ website:
               href: api/comparison.ComparerPlotter.qmd
             - api/ComparerCollection.qmd
             - text: "ComparerCollectionPlotter"
-              href: api/comparison.ComparerCollectionPlotter.qmd            
+              href: api/comparison.ComparerCollectionPlotter.qmd
+            - text: "VerticalAccessor"
+              href: api/comparison.VerticalAccessor.qmd
+            - text: "VerticalPlotter"
+              href: api/comparison.VerticalPlotter.qmd
         - section: "Skill"
-          contents:            
+          contents:
             - api/SkillTable.qmd
             - text: "SkillArray"
               href: api/skill.SkillArray.qmd
@@ -118,6 +124,10 @@ website:
               href: api/skill_grid.SkillGrid.qmd
             - text: "SkillGridArray"
               href: api/skill_grid.SkillGridArray.qmd
+            - text: "SkillProfile"
+              href: api/skill_profile.SkillProfile.qmd
+            - text: "SkillProfileArray"
+              href: api/skill_profile.SkillProfileArray.qmd
         - text: "Plotting"
           href: api/plotting.qmd
           contents:
@@ -172,6 +182,7 @@ quartodoc:
         - TrackObservation
         - NodeObservation
         - ReachObservation
+        - VerticalObservation
     - title: Model Result
       desc: ""
       contents:
@@ -184,6 +195,7 @@ quartodoc:
         - GridModelResult
         - DummyModelResult
         - NetworkModelResult
+        - VerticalModelResult
     - title: Matching
       desc: Matching functions
       contents:
@@ -198,6 +210,7 @@ quartodoc:
         - name: Comparer
           members:
             - plot
+            - vertical
             - skill
             - gridded_skill
             - score
@@ -228,6 +241,8 @@ quartodoc:
             - save
             - load
         - name: comparison.ComparerCollectionPlotter
+        - name: comparison.VerticalAccessor
+        - name: comparison.VerticalPlotter
 
     - title: Skill
       desc: ""
@@ -237,6 +252,8 @@ quartodoc:
         - name: skill.SkillArrayPlotter
         - name: skill_grid.SkillGrid
         - name: skill_grid.SkillGridArray
+        - name: skill_profile.SkillProfile
+        - name: skill_profile.SkillProfileArray
     
     - title: Plotting
       desc: ""

--- a/src/modelskill/comparison/__init__.py
+++ b/src/modelskill/comparison/__init__.py
@@ -8,6 +8,7 @@ from ._comparison import Comparer
 from ._collection import ComparerCollection
 from ._comparer_plotter import ComparerPlotter
 from ._collection_plotter import ComparerCollectionPlotter
+from ._vertical_comparison import VerticalAccessor, VerticalPlotter
 
 
 __all__ = [
@@ -15,4 +16,6 @@ __all__ = [
     "ComparerCollection",
     "ComparerPlotter",
     "ComparerCollectionPlotter",
+    "VerticalAccessor",
+    "VerticalPlotter",
 ]


### PR DESCRIPTION
## Summary

- Adds `VerticalObservation`, `VerticalModelResult`, `VerticalAccessor`, `VerticalPlotter`, `SkillProfile`, and `SkillProfileArray` to the quartodoc sections and sidebar so the existing functionality has generated reference pages.
- Re-exports `VerticalAccessor` and `VerticalPlotter` from `modelskill.comparison` so quartodoc resolves them by the same `comparison.<Class>` path used for `ComparerPlotter`.
- Resolves the dangling `` `modelskill.VerticalObservation` `` cross-reference warning emitted by `quarto render` for `api/obs.qmd`, `api/observation.qmd`, and `api/DfsuModelResult.qmd`.

User-guide coverage of the vertical workflow is tracked separately in #645.

## Test plan

- [ ] `just docs` completes without "Found no matches" warnings
- [ ] New pages render: `api/VerticalObservation.html`, `api/VerticalModelResult.html`, `api/comparison.VerticalAccessor.html`, `api/comparison.VerticalPlotter.html`, `api/skill_profile.SkillProfile.html`, `api/skill_profile.SkillProfileArray.html`
- [ ] `Comparer` page lists `vertical` accessor