### PR TITLE
Add lychee link-check recipes to justfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,16 @@ uv sync --group docs
 make docs
 ```
 
+### Checking links
+
+A full doc render takes minutes. To validate links faster, install [lychee](https://lychee.cli.rs/) (`brew install lychee`, `cargo install lychee`, or grab a binary from the [releases page](https://github.com/lycheeverse/lychee/releases)), then:
+
+```bash
+just linkcheck         # .qmd sources, offline (no render needed)
+just linkcheck-site    # render with --no-execute, then check rendered HTML (catches quartodoc cross-refs and anchors)
+just linkcheck-online  # .qmd sources + external URLs
+```
+
 ## Running specific tests
 
 ```bash

--- a/justfile
+++ b/justfile
@@ -42,6 +42,27 @@ docs:
     cd docs; uv run quartodoc build; uv run quarto render
     if (!(Test-Path docs/_site/index.html)) { Write-Error "Error: index.html not found."; exit 1 }
 
+# Build docs without executing Python (fast; produces a link-checkable _site/)
+[unix]
+docs-fast:
+    cd docs && uv run quartodoc build && uv run quarto render --no-execute
+
+[windows]
+docs-fast:
+    cd docs; uv run quartodoc build; uv run quarto render --no-execute
+
+# Check links in .qmd sources (offline, no render needed)
+linkcheck:
+    lychee --offline --include-fragments 'docs/**/*.qmd'
+
+# Check links in rendered site (catches quartodoc cross-refs and anchors)
+linkcheck-site: docs-fast
+    lychee --offline --include-fragments 'docs/_site/**/*.html'
+
+# Check external URLs in .qmd sources (hits the network)
+linkcheck-online:
+    lychee --include-fragments 'docs/**/*.qmd'
+
 # Clean build artifacts
 [unix]
 clean:


### PR DESCRIPTION
## Summary

A full `just docs` render takes minutes, so iterating on broken links is slow. This adds three [`lychee`](https://lychee.cli.rs/) recipes that give faster feedback:

- `just linkcheck` — `.qmd` sources, offline. Useful as a quick sanity check while writing prose; ~20ms locally. Does **not** see Quarto cross-refs like `` [foo](`modelskill.X`) `` since those aren't standard markdown.
- `just linkcheck-site` — renders the docs with `quarto render --no-execute` (a new `docs-fast` recipe; skips Python execution) and runs lychee against the resulting `_site/`. This is where quartodoc-generated cross-refs and anchors actually become checkable. Locally finds hundreds of real broken refs in the current site in ~85ms.
- `just linkcheck-online` — `.qmd` sources + external URLs.

Install instructions for lychee are added to [CONTRIBUTING](../blob/docs-linkcheck-lychee/CONTRIBUTING.md#checking-links).

## Limitations

Lychee verifies that link *targets* exist, not that they are semantically correct. A link whose text describes "Observation" but whose target is a (real) `ModelResult` page will pass — that class of bug still needs human review.

## Test plan

- [ ] `just linkcheck` runs and exits 0 against current `.qmd` sources
- [ ] `just linkcheck-site` builds via `--no-execute` and surfaces existing broken refs in the rendered site
- [ ] `just --list` shows the new recipes with descriptions