### PR TITLE
fix: parser mutates caller's DataFrame index name

### DIFF
--- a/src/modelskill/timeseries/_vertical.py
+++ b/src/modelskill/timeseries/_vertical.py
@@ -132,8 +132,7 @@ def _parse_vertical_input(
     if isinstance(data, mikeio.Dataset):
         ds = data.to_xarray()
     elif isinstance(data, pd.DataFrame):
-        data.index.name = "time"
-        ds = data.to_xarray()
+        ds = data.rename_axis("time").to_xarray()
     else:
         assert len(data.dims) == 1, "Only 0-dimensional data are supported"
         if data.coords[list(data.coords)[0]].name != "time":

--- a/tests/model/test_vertical.py
+++ b/tests/model/test_vertical.py
@@ -211,6 +211,17 @@ class TestVerticalModelResult:
         mr.name = "changed_name"
         assert mr2.name == "salt_model"
 
+    def test_construction_does_not_mutate_input_dataframe(self, vertical_model_df):
+        assert vertical_model_df.index.name is None
+        original_columns = list(vertical_model_df.columns)
+
+        ms.VerticalModelResult(
+            vertical_model_df, item="Salinity", z_item="z", x=12.0, y=55.0
+        )
+
+        assert vertical_model_df.index.name is None
+        assert list(vertical_model_df.columns) == original_columns
+
     # ================
     # Test extract profile and align to obs profiles from dfsu
     # ===============

--- a/tests/observation/test_vertical_obs.py
+++ b/tests/observation/test_vertical_obs.py
@@ -250,6 +250,17 @@ class TestVerticalObservation:
         assert obs2.attrs["station"] == "A"
         assert obs2.name == obs.name
 
+    def test_construction_does_not_mutate_input_dataframe(self, _vertical_df):
+        assert _vertical_df.index.name is None
+        original_columns = list(_vertical_df.columns)
+
+        ms.VerticalObservation(
+            _vertical_df, item="value", z_item="z", x=12.0, y=55.0
+        )
+
+        assert _vertical_df.index.name is None
+        assert list(_vertical_df.columns) == original_columns
+
     def test_to_dataframe(self, _vertical_df):
         obs = ms.VerticalObservation(
             _vertical_df,


### PR DESCRIPTION
`_parse_vertical_input` set `data.index.name = "time"` on a column-sliced view of the caller's DataFrame ([_vertical.py:135](https://github.com/DHI/modelskill/blob/main/src/modelskill/timeseries/_vertical.py#L135)). Pandas shares the `Index` object between a column slice and its source, so the rename leaked back: a caller's `df.index.name` flipped from `None` to `"time"` after constructing either `VerticalObservation` or `VerticalModelResult`.

Fix: rewrite as `data.rename_axis("time").to_xarray()`, which returns a new DataFrame and leaves the caller's index untouched.

The first commit adds regression tests for both classes pinning the non-mutation contract; the second applies the parser fix.