### PR TITLE
update version to 1.4.0a3

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -18,11 +18,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    env:
-      DOTNET_ROLL_FORWARD: LatestPatch
     strategy:
       matrix:
-        python-version: ["3.11", "3.13"]
+        python-version: ["3.11", "3.14"]
         pandas-version: ["pandas2", "pandas3"]  # TODO: drop pandas2 once 3.x is well-established
 
     steps:
@@ -36,13 +34,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
-      - name: Set up .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0.x'
-
       - name: Install dependencies
-        run: uv sync --group test --group networks --no-dev
+        #run: uv sync --group test --group networks --no-dev
+        run: uv sync --group test --no-dev
 
       - name: Install pandas 2.x
         if: matrix.pandas-version == 'pandas2'
@@ -61,22 +55,23 @@ jobs:
       - name: Test
         run: just test
 
-  build-no-networks:
-    runs-on: ubuntu-latest
+  # TODO: activate once above runs with -- group networks
+  # build-no-networks:
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - uses: extractions/setup-just@v3
+  #     - uses: extractions/setup-just@v3
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          python-version: "3.11"
-          enable-cache: true
+  #     - name: Set up uv
+  #       uses: astral-sh/setup-uv@v6
+  #       with:
+  #         python-version: "3.11"
+  #         enable-cache: true
 
-      - name: Install dependencies (without networks)
-        run: uv sync --group test --no-dev
+  #     - name: Install dependencies (without networks)
+  #       run: uv sync --group test --no-dev
 
-      - name: Test
-        run: just test
+  #     - name: Test
+  #       run: just test

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -18,6 +18,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    env:
+      DOTNET_ROLL_FORWARD: LatestPatch
     strategy:
       matrix:
         python-version: ["3.11", "3.13"]

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -20,11 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.11", "3.14"]
         pandas-version: ["pandas2", "pandas3"]  # TODO: drop pandas2 once 3.x is well-established
-        exclude:
-          - python-version: "3.10"
-            pandas-version: "pandas3"
 
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +65,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           enable-cache: true
 
       - name: Install dependencies (without networks)

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -35,7 +35,8 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        #run: uv sync --group test --group networks --no-dev
+        # (Reactivate once it works with mikeio1d)
+        #run: uv sync --group test --group networks --no-dev 
         run: uv sync --group test --no-dev
 
       - name: Install pandas 2.x

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.14"]
+        python-version: ["3.11", "3.13"]
         pandas-version: ["pandas2", "pandas3"]  # TODO: drop pandas2 once 3.x is well-established
 
     steps:
@@ -33,6 +33,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Install dependencies
         run: uv sync --group test --group networks --no-dev

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.11", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,6 +12,8 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
+    env:
+      DOTNET_ROLL_FORWARD: LatestPatch
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.14"]
+        python-version: ["3.11", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -24,8 +24,12 @@ jobs:
       with:
         enable-cache: true
         python-version: ${{ matrix.python-version }}
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
     - name: Install dependencies
-      run: uv sync --group test --no-dev
+      run: uv sync --group test --group networks --no-dev
     - name: Test with pytest
       run: |
         uv run pytest --ignore tests/performance/ --ignore tests/notebooks/ --disable-warnings
@@ -43,7 +47,7 @@ jobs:
     - name: Set up uv
       uses: astral-sh/setup-uv@v6
       with:
-        python-version: "3.14"
+        python-version: "3.13"
         enable-cache: true
     - name: Install dependencies
       run: uv sync --group test --no-dev

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,12 +12,10 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
-    env:
-      DOTNET_ROLL_FORWARD: LatestPatch
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.13"]
+        python-version: ["3.11", "3.14"]
 
     steps:
     - uses: actions/checkout@v4
@@ -26,12 +24,8 @@ jobs:
       with:
         enable-cache: true
         python-version: ${{ matrix.python-version }}
-    - name: Set up .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '8.0.x'
     - name: Install dependencies
-      run: uv sync --group test --group networks --no-dev
+      run: uv sync --group test --no-dev
     - name: Test with pytest
       run: |
         uv run pytest --ignore tests/performance/ --ignore tests/notebooks/ --disable-warnings
@@ -49,7 +43,7 @@ jobs:
     - name: Set up uv
       uses: astral-sh/setup-uv@v6
       with:
-        python-version: "3.13"
+        python-version: "3.14"
         enable-cache: true
     - name: Install dependencies
       run: uv sync --group test --no-dev
@@ -57,4 +51,3 @@ jobs:
       run: uv build
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-

--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.13"]
+        python-version: ["3.11", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.11", "3.14"]
         exclude:
           - os: windows-latest
             python-version: "3.14"

--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -14,13 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.14"]
-        exclude:
-          - os: windows-latest
-            python-version: "3.14"
-        include:
-          - os: windows-latest
-            python-version: "3.14"
+        python-version: ["3.11", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,17 +29,17 @@ authors = [
 description = "Compare results from simulations with observations."
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 
@@ -78,7 +78,7 @@ ignore = ["E501"]
 select = ["E4", "E7", "E9", "F", "D200", "D205"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 ignore_missing_imports = true
 warn_unreachable = false
 no_implicit_optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ wheel-exclude = ["**/.mypy_cache**", "**/.mypy_cache/**"]
 
 [project]
 name = "modelskill"
-version = "1.4.0a2"
+version = "1.4.0a3"
 dependencies = [
     "numpy  > 1.24.4",
     "pandas >= 1.4, < 3.0", # TODO remove upper limit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 


### PR DESCRIPTION
Text to release note:

 ModelSkill 1.4.0a3
   - Dropped Python 3.10 support; minimum version is now Python 3.11
   - Vertical skill – Profile-based skill assessment (VerticalObservation, VerticalModelResult, SkillProfile) (#585)
   - Network: Reach observations – Extract and compare data along reaches (renamed from "edge") (#637, #642)
   - Network: Node/reach subsets – Filter network model results to specific nodes and reaches (#625)
   - Fix pandas 3.0 compatibility (#561)
   - 
