### PR TITLE
perf: lazy-load scipy in metrics and scatter plot

### DIFF
--- a/src/modelskill/metrics.py
+++ b/src/modelskill/metrics.py
@@ -20,7 +20,6 @@ from typing import (
 import numpy as np
 import pandas as pd
 from numpy.typing import ArrayLike
-from scipy import stats
 
 from .settings import options
 
@@ -590,6 +589,9 @@ def peak_ratio(
     # Use total_seconds() to handle any datetime precision (ns, us, ms, s)
     dt = time[1:] - time[:-1]
     dt_seconds = dt.total_seconds().values
+    # Lazy import: scipy.stats is heavy and only used by a few metrics, not on package import
+    from scipy import stats
+
     dt_mode_seconds = float(stats.mode(dt_seconds, keepdims=False)[0])
     N_years = dt_mode_seconds / 24 / 3600 / 365.25 * len(time)
     peak_index, AAP_ = _partial_duration_series(

--- a/src/modelskill/plotting/_scatter.py
+++ b/src/modelskill/plotting/_scatter.py
@@ -11,7 +11,6 @@ from matplotlib.cm import ScalarMappable
 from matplotlib import patches
 from matplotlib.axes import Axes
 from matplotlib.ticker import MaxNLocator
-from scipy import interpolate
 import pandas as pd
 
 import modelskill.settings as settings
@@ -766,6 +765,9 @@ def __scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
     yg = yg.ravel()
 
     ## Interpolate histogram density data to scatter data
+    # Lazy import: scipy.interpolate is heavy and only needed here, not on package import
+    from scipy import interpolate
+
     Z_grid = interpolate.griddata((xg, yg), hist, (x, y), method=method)
 
     # Replace negative values (should there be some) in case of 'cubic' interpolation


### PR DESCRIPTION
## Summary

- Defer `scipy.stats` import in `metrics.py` to `peak_ratio()` (the only function using it at module level).
- Defer `scipy.interpolate` import in `plotting/_scatter.py` to `__scatter_density()` (the only caller).

Cuts `import modelskill` from ~3.3s to ~1.45s on my machine. Negligible difference for long-running scripts, but notebook/REPL users feel the snappier startup.