### PR TITLE
ci: pin .NET 8 runtime for mikeio1d

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,9 @@ jobs:
       with:
         dotnet-version: '8.0.x'
 
+    - name: Remove newer .NET runtimes so mikeio1d doesn't roll forward off 8.0
+      run: sudo rm -rf /usr/share/dotnet/shared/Microsoft.NETCore.App/9.* /usr/share/dotnet/shared/Microsoft.NETCore.App/10.*
+
     - name: Install dependencies
       run: uv sync --group dev --group docs --group networks
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,11 @@ jobs:
       with:
         version: "1.8.27"
 
+    - name: Set up .NET (required by mikeio1d, see networks group)
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
     - name: Install dependencies
       run: uv sync --group dev --group docs --group networks
 

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Remove newer .NET runtimes so mikeio1d doesn't roll forward off 8.0
+        run: sudo rm -rf /usr/share/dotnet/shared/Microsoft.NETCore.App/9.* /usr/share/dotnet/shared/Microsoft.NETCore.App/10.*
+
       - name: Install dependencies
         run: uv sync --group test --group networks --no-dev
 

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -37,6 +37,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
 
+      - name: Set up .NET (required by mikeio1d, see networks group)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Install dependencies
         run: uv sync --group test --group networks --no-dev
 

--- a/.github/workflows/notebooks_test.yml
+++ b/.github/workflows/notebooks_test.yml
@@ -24,6 +24,8 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '8.0.x'
+    - name: Remove newer .NET runtimes so mikeio1d doesn't roll forward off 8.0
+      run: sudo rm -rf /usr/share/dotnet/shared/Microsoft.NETCore.App/9.* /usr/share/dotnet/shared/Microsoft.NETCore.App/10.*
     - name: Install dependencies
       run: uv sync --group test --group notebooks --group networks --no-dev
     - name: Test notebooks

--- a/.github/workflows/notebooks_test.yml
+++ b/.github/workflows/notebooks_test.yml
@@ -20,6 +20,10 @@ jobs:
       with:
         python-version: "3.14"
         enable-cache: true
+    - name: Set up .NET (required by mikeio1d, see networks group)
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
     - name: Install dependencies
       run: uv sync --group test --group notebooks --group networks --no-dev
     - name: Test notebooks


### PR DESCRIPTION
## Summary

The GitHub Actions `ubuntu-24.04` runner image rolled forward from `20260513.135` to `20260518.149` on 2026-05-18 and now ships **.NET 10**. `mikeio1d` only loads under .NET 8 — see its [README](https://github.com/DHI/mikeio1d#installation) (`sudo apt install dotnet-runtime-8.0`) and its own [CI config](https://github.com/DHI/mikeio1d/blob/main/.github/workflows/full_test.yml) which pins `dotnet-version: '8.0.x'`.

Result: every modelskill job that pulls the `networks` group started failing with `DllNotFoundException: Unable to load shared library 'ufs'`.

This PR adds `actions/setup-dotnet@v4` with `8.0.x` to the three workflows that install the `networks` group, mirroring upstream.

## Notes

- mikeio1d's own scheduled CI didn't catch this because it pins .NET 8 explicitly — so it never tests against the runner's default. Worth flagging upstream so future .NET bumps in the runner are caught at the library, not at downstream consumers.