### PR TITLE
Drop Python 3.11 support

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.14"]
+        python-version: ["3.12", "3.14"]
         pandas-version: ["pandas2", "pandas3"]  # TODO: drop pandas2 once 3.x is well-established
 
     steps:
@@ -65,7 +65,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           enable-cache: true
 
       - name: Install dependencies (without networks)

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.14"]
+        python-version: ["3.12", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.14"]
+        python-version: ["3.12", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,13 @@ authors = [
 description = "Compare results from simulations with observations."
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
@@ -77,7 +76,7 @@ ignore = ["E501"]
 select = ["E4", "E7", "E9", "F", "D200", "D205"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 ignore_missing_imports = true
 warn_unreachable = false
 no_implicit_optional = true

--- a/src/modelskill/comparison/_collection.py
+++ b/src/modelskill/comparison/_collection.py
@@ -214,7 +214,7 @@ class ComparerCollection(Mapping):
         return ComparerCollection(cmps)
 
     @overload
-    def __getitem__(self, x: slice | Iterable[Hashable]) -> ComparerCollection: ...
+    def __getitem__(self, x: slice | Iterable[Hashable]) -> ComparerCollection: ...  # type: ignore[overload-overlap]
 
     @overload
     def __getitem__(self, x: int | Hashable) -> Comparer: ...

--- a/src/modelskill/comparison/_vertical_comparison.py
+++ b/src/modelskill/comparison/_vertical_comparison.py
@@ -169,7 +169,9 @@ class VerticalPlotter:
         V = v.reshape(len(T), n_layers)
         T_grid, _ = np.meshgrid(T, np.arange(n_layers), indexing="ij")
         cf = ax.contourf(T_grid, Z, V, **kwargs)
-        cbar = ax.figure.colorbar(cf, ax=ax)
+        fig = ax.figure
+        assert fig is not None
+        cbar = fig.colorbar(cf, ax=ax)
         cbar.set_label(cmp._unit_text)
         if self._pos_z():
             ax.invert_yaxis()


### PR DESCRIPTION
Bumps the minimum Python to 3.12 across `requires-python`, the trove classifiers, mypy's target, and the CI matrices, and fixes the two mypy errors that 3.11 was masking.

mikeio's `main` branch now requires Python >=3.12 ([SPEC 0](https://scientific-python.org/specs/spec-0000/)), which made the `test-mikeio-main` canary job [fail at dependency resolution](https://github.com/DHI/modelskill/actions/runs/28353186613/job/83990146209): uv resolves for every supported Python version, and 3.11 is no longer satisfiable. Since mikeio is a core dependency, modelskill follows the same policy.

This also fixes the typecheck CI, where numpy's current type stubs use the 3.12+ `type` statement that mypy rejects when targeting 3.11.