### PR TITLE
Drop Python 3.11 support

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.14"]
+        python-version: ["3.12", "3.14"]
         pandas-version: ["pandas2", "pandas3"]  # TODO: drop pandas2 once 3.x is well-established
 
     steps:
@@ -65,7 +65,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           enable-cache: true
 
       - name: Install dependencies (without networks)

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.14"]
+        python-version: ["3.12", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.11", "3.14"]
+        python-version: ["3.12", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,13 @@ authors = [
 description = "Compare results from simulations with observations."
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
@@ -77,7 +76,7 @@ ignore = ["E501"]
 select = ["E4", "E7", "E9", "F", "D200", "D205"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 ignore_missing_imports = true
 warn_unreachable = false
 no_implicit_optional = true


### PR DESCRIPTION
Bumps the minimum Python to 3.12 across `requires-python`, the trove classifiers, mypy's target, and the CI matrices.

mikeio's `main` branch now requires Python >=3.12 ([SPEC 0](https://scientific-python.org/specs/spec-0000/)), which made the `test-mikeio-main` canary job [fail at dependency resolution](https://github.com/DHI/modelskill/actions/runs/28353186613/job/83990146209): uv resolves for every supported Python version, and 3.11 is no longer satisfiable. Since mikeio is a core dependency, modelskill follows the same policy.

This also fixes the typecheck CI, where numpy's current type stubs use the 3.12+ `type` statement that mypy rejects when targeting 3.11.