### PR TITLE
Restrict GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/notebooks_test.yml
+++ b/.github/workflows/notebooks_test.yml
@@ -8,6 +8,9 @@ on:
     types: [review_requested, ready_for_review]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,6 +8,9 @@ on:
     types: [published]
   workflow_dispatch:
     
+permissions:
+  contents: read
+
 jobs:
 
   test:
@@ -34,6 +37,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
 

--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -7,6 +7,9 @@ on:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 5 */3 * *'
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/test_mikeio_main.yml
+++ b/.github/workflows/test_mikeio_main.yml
@@ -8,6 +8,9 @@ on:
     # Run weekly on Mondays at 5:00 AM UTC
     - cron: '0 5 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   test-mikeio-main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Workflows without an explicit `permissions` block use the repository or organization default token permissions. For repositories created before February 2023 that default is read-write, so every job runs with a token that can push to the repo even though all it does is check out and run tests.

CodeQL flags this as [`actions/missing-workflow-permissions`](https://github.com/DHI/modelskill/security/code-scanning?query=is%3Aopen+rule%3Aactions%2Fmissing-workflow-permissions) (7 open alerts). Setting the permissions explicitly documents what each workflow actually needs and keeps it restricted if the default changes or the workflow is copied elsewhere.

`contents: read` at the workflow root is enough for all of them; the PyPI deploy job keeps `id-token: write` for trusted publishing and now states `contents: read` too, since a job-level block replaces rather than extends the root one.

See [Assigning permissions to jobs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/assigning-permissions-to-jobs).